### PR TITLE
Add modal editor for node fields

### DIFF
--- a/public/nodeTypes.json
+++ b/public/nodeTypes.json
@@ -35,6 +35,31 @@
           "type": "string",
           "required": true,
           "default": "https://api.openai.com"
+        },
+        {
+          "id": "timeout",
+          "label": "Timeout",
+          "type": "integer",
+          "default": 30
+        },
+        {
+          "id": "temperature",
+          "label": "Temperature",
+          "type": "float",
+          "default": 0.7
+        },
+        {
+          "id": "useProxy",
+          "label": "Use Proxy",
+          "type": "bool",
+          "default": false
+        },
+        {
+          "id": "model",
+          "label": "Model",
+          "type": "enum",
+          "options": ["gpt-3.5-turbo", "gpt-4-turbo"],
+          "default": "gpt-3.5-turbo"
         }
       ]
     },

--- a/src/components/CustomNode.tsx
+++ b/src/components/CustomNode.tsx
@@ -1,6 +1,5 @@
 // src/components/CustomNode.tsx
 import { Handle, Node, NodeProps, Position } from '@xyflow/react';
-import { clsx } from 'clsx';
 import { useWorkflowStore } from '../store/workflowStore';
 import type { NodeInstance } from '../types';
 
@@ -18,9 +17,7 @@ export default function CustomNode({ data }: NodeProps<RFNode>) {
   const nodeType = useWorkflowStore(
     (s) => s.nodeTypes.find((nt) => nt.id === nodeInst.nodeTypeId)!
   );
-  const selected = useWorkflowStore((s) => s.selected);
   const openEditor = useWorkflowStore((s) => s.openEditor);
-  const isSelected = selected.includes(nodeInst.uuid);
 
   return (
     <div className="custom-node">
@@ -56,10 +53,12 @@ export default function CustomNode({ data }: NodeProps<RFNode>) {
         </div>
       ))}
 
-      {isSelected && nodeType.fields.length > 0 && (
-        <button className="edit-btn" onClick={() => openEditor(nodeInst.uuid)}>
-          Edit
-        </button>
+      {nodeType.fields.length > 0 && (
+        <div className="node-row edit-row">
+          <button className="edit-btn" onClick={() => openEditor(nodeInst.uuid)}>
+            Edit
+          </button>
+        </div>
       )}
     </div>
   );

--- a/src/components/CustomNode.tsx
+++ b/src/components/CustomNode.tsx
@@ -18,6 +18,9 @@ export default function CustomNode({ data }: NodeProps<RFNode>) {
   const nodeType = useWorkflowStore(
     (s) => s.nodeTypes.find((nt) => nt.id === nodeInst.nodeTypeId)!
   );
+  const selected = useWorkflowStore((s) => s.selected);
+  const openEditor = useWorkflowStore((s) => s.openEditor);
+  const isSelected = selected.includes(nodeInst.uuid);
 
   return (
     <div className="custom-node">
@@ -52,6 +55,12 @@ export default function CustomNode({ data }: NodeProps<RFNode>) {
           />
         </div>
       ))}
+
+      {isSelected && nodeType.fields.length > 0 && (
+        <button className="edit-btn" onClick={() => openEditor(nodeInst.uuid)}>
+          Edit
+        </button>
+      )}
     </div>
   );
 }

--- a/src/components/EditorCanvas.tsx
+++ b/src/components/EditorCanvas.tsx
@@ -44,6 +44,8 @@ function FlowInner() {
   const addNode = useWorkflowStore((s) => s.addNode);
   const addEdgeStore = useWorkflowStore((s) => s.addEdge);
   const removeEdge = useWorkflowStore((s) => s.removeEdge);
+  const moveNode = useWorkflowStore((s) => s.moveNode);
+  const setSelected = useWorkflowStore((s) => s.setSelected);
 
   const nodeDefs = useWorkflowStore((s) => s.nodeTypes);
   const hierarchy = useWorkflowStore((s) => s.typeHierarchy);
@@ -77,6 +79,18 @@ function FlowInner() {
 
   /* -------- drag-and-drop ------------------------------------------------- */
   const { screenToFlowPosition } = useReactFlow<RFNode, RFEdge>();
+
+  const handleNodesChange = useCallback(
+    (changes: NodeChange[]) => {
+      changes.forEach((c) => {
+        if (c.type === 'position' && c.position) {
+          moveNode(c.id as string, c.position);
+        }
+      });
+      onNodesChange(changes);
+    },
+    [onNodesChange, moveNode]
+  );
 
   const onDrop = useCallback(
     (evt: React.DragEvent) => {
@@ -138,7 +152,7 @@ function FlowInner() {
         nodes={nodes}
         edges={edges}
         nodeTypes={rfNodeTypes}
-        onNodesChange={onNodesChange}
+        onNodesChange={handleNodesChange}
         onEdgesChange={(changes) => {
           changes.forEach((c) => c.type === 'remove' && removeEdge(c.id as string));
           onEdgesChange(changes);
@@ -146,6 +160,7 @@ function FlowInner() {
         onConnect={onConnect}
         onDrop={onDrop}
         onDragOver={onDragOver}
+        onSelectionChange={(sel) => setSelected(sel.nodes.map((n) => n.id))}
         fitView
       >
         <Background />

--- a/src/components/PropertiesPanel.tsx
+++ b/src/components/PropertiesPanel.tsx
@@ -4,28 +4,27 @@ import type { Field, NodeInstance } from '../types';
 import type { JSX } from 'react';
 
 export default function PropertiesPanel() {
-  const selected = useWorkflowStore((s) => s.selected);
-  const nodes    = useWorkflowStore((s) => s.nodes);
-  const types    = useWorkflowStore((s) => s.nodeTypes);
+  const editing = useWorkflowStore((s) => s.editing);
+  const nodes   = useWorkflowStore((s) => s.nodes);
+  const types   = useWorkflowStore((s) => s.nodeTypes);
 
-  const setSelected = useWorkflowStore((s) => s.setSelected);
+  const closeEditor = useWorkflowStore((s) => s.closeEditor);
 
-  const nodeId = selected[0];
-  if (!nodeId) return null;
+  if (!editing) return null;
 
-  const node     = nodes[nodeId];
+  const node     = nodes[editing];
   const nodeType = types.find((t) => t.id === node.nodeTypeId);
   if (!nodeType) return null;
 
   return (
     <>
-      <div className="modal-backdrop" onClick={() => setSelected([])} />
-      <div className="modal">
+      <div className="modal-backdrop" onClick={closeEditor} />
+      <div className="modal" onClick={(e) => e.stopPropagation()}>
         <h3>{nodeType.name}</h3>
         {nodeType.fields.map((f) => (
           <FieldInput key={f.id} field={f} node={node} />
         ))}
-        <button onClick={() => setSelected([])}>Close</button>
+        <button onClick={closeEditor}>Close</button>
       </div>
     </>
   );

--- a/src/components/PropertiesPanel.tsx
+++ b/src/components/PropertiesPanel.tsx
@@ -1,11 +1,14 @@
 import { useState } from 'react';
 import { useWorkflowStore } from '../store/workflowStore';
 import type { Field, NodeInstance } from '../types';
+import type { JSX } from 'react';
 
 export default function PropertiesPanel() {
   const selected = useWorkflowStore((s) => s.selected);
   const nodes    = useWorkflowStore((s) => s.nodes);
   const types    = useWorkflowStore((s) => s.nodeTypes);
+
+  const setSelected = useWorkflowStore((s) => s.setSelected);
 
   const nodeId = selected[0];
   if (!nodeId) return null;
@@ -15,34 +18,89 @@ export default function PropertiesPanel() {
   if (!nodeType) return null;
 
   return (
-    <aside className="props">
-      <h3>{nodeType.name}</h3>
-      {nodeType.fields.map((f) => (
-        <FieldInput key={f.id} field={f} node={node} />
-      ))}
-    </aside>
+    <>
+      <div className="modal-backdrop" onClick={() => setSelected([])} />
+      <div className="modal">
+        <h3>{nodeType.name}</h3>
+        {nodeType.fields.map((f) => (
+          <FieldInput key={f.id} field={f} node={node} />
+        ))}
+        <button onClick={() => setSelected([])}>Close</button>
+      </div>
+    </>
   );
 }
 
-function FieldInput({
-  field,
-  node
-}: {
-  field: Field;
-  node:  NodeInstance;
-}) {
-  const [value, setValue] = useState(
-    node.fields[field.id] ?? field.default ?? ''
-  );
+function FieldInput({ field, node }: { field: Field; node: NodeInstance }) {
+  const update = useWorkflowStore((s) => s.updateNodeField);
+  const initial = node.fields[field.id] ?? field.default ?? '';
+  const [value, setValue] = useState<any>(initial);
+
+  const onChange = (val: unknown) => {
+    setValue(val);
+    update(node.uuid, field.id, val);
+  };
+
+  let input: JSX.Element;
+  switch (field.type) {
+    case 'integer':
+      input = (
+        <input
+          type="number"
+          step="1"
+          value={value as number}
+          onChange={(e) => onChange(Number(e.target.value))}
+        />
+      );
+      break;
+    case 'float':
+      input = (
+        <input
+          type="number"
+          step="0.01"
+          value={value as number}
+          onChange={(e) => onChange(Number(e.target.value))}
+        />
+      );
+      break;
+    case 'bool':
+      input = (
+        <input
+          type="checkbox"
+          checked={Boolean(value)}
+          onChange={(e) => onChange(e.target.checked)}
+        />
+      );
+      break;
+    case 'enum':
+      input = (
+        <select
+          value={String(value)}
+          onChange={(e) => onChange(e.target.value)}
+        >
+          {field.options?.map((opt) => (
+            <option key={opt} value={opt}>
+              {opt}
+            </option>
+          ))}
+        </select>
+      );
+      break;
+    default:
+      input = (
+        <input
+          type="text"
+          value={String(value)}
+          onChange={(e) => onChange(e.target.value)}
+        />
+      );
+      break;
+  }
 
   return (
-    <label>
+    <label style={{ display: 'block', marginBottom: '0.5rem' }}>
       {field.label}
-      <input
-        type="text"
-        value={String(value)}
-        onChange={(e) => setValue(e.target.value)}
-      />
+      {input}
     </label>
   );
 }

--- a/src/components/PropertiesPanel.tsx
+++ b/src/components/PropertiesPanel.tsx
@@ -64,11 +64,14 @@ function FieldInput({ field, node }: { field: Field; node: NodeInstance }) {
       break;
     case 'bool':
       input = (
-        <input
-          type="checkbox"
-          checked={Boolean(value)}
-          onChange={(e) => onChange(e.target.checked)}
-        />
+        <span className="switch">
+          <input
+            type="checkbox"
+            checked={Boolean(value)}
+            onChange={(e) => onChange(e.target.checked)}
+          />
+          <span className="slider" />
+        </span>
       );
       break;
     case 'enum':
@@ -97,7 +100,7 @@ function FieldInput({ field, node }: { field: Field; node: NodeInstance }) {
   }
 
   return (
-    <label style={{ display: 'block', marginBottom: '0.5rem' }}>
+    <label className="field-label">
       {field.label}
       {input}
     </label>

--- a/src/store/workflowStore.ts
+++ b/src/store/workflowStore.ts
@@ -24,6 +24,9 @@ interface WorkflowState {
   addEdge: (edge: EdgeInstance) => void;
   removeEdge: (id: string) => void;
   setTheme: (t: 'light' | 'dark') => void;
+  setSelected: (ids: string[]) => void;
+  updateNodeField: (uuid: string, fieldId: string, value: unknown) => void;
+  moveNode: (uuid: string, pos: { x: number; y: number }) => void;
 }
 
 export const useWorkflowStore = create<WorkflowState>()(
@@ -88,6 +91,25 @@ export const useWorkflowStore = create<WorkflowState>()(
       set((s) => {
         s.theme = t;
         localStorage.setItem('theme', t);
+      }),
+
+    setSelected: (ids) =>
+      set((s) => {
+        s.selected = ids;
+      }),
+
+    updateNodeField: (uuid, fieldId, value) =>
+      set((s) => {
+        if (s.nodes[uuid]) {
+          s.nodes[uuid].fields[fieldId] = value;
+        }
+      }),
+
+    moveNode: (uuid, pos) =>
+      set((s) => {
+        if (s.nodes[uuid]) {
+          s.nodes[uuid].position = pos;
+        }
       })
   }))
 );

--- a/src/store/workflowStore.ts
+++ b/src/store/workflowStore.ts
@@ -9,6 +9,7 @@ interface WorkflowState {
   nodes: Record<string, NodeInstance>;
   edges: EdgeInstance[];
   selected: string[];
+  editing: string | null;
   theme: 'light' | 'dark';
   undoStack: unknown[];
   redoStack: unknown[];
@@ -25,6 +26,8 @@ interface WorkflowState {
   removeEdge: (id: string) => void;
   setTheme: (t: 'light' | 'dark') => void;
   setSelected: (ids: string[]) => void;
+  openEditor: (id: string) => void;
+  closeEditor: () => void;
   updateNodeField: (uuid: string, fieldId: string, value: unknown) => void;
   moveNode: (uuid: string, pos: { x: number; y: number }) => void;
 }
@@ -37,6 +40,7 @@ export const useWorkflowStore = create<WorkflowState>()(
     nodes: {},
     edges: [],
     selected: [],
+    editing: null,
     theme:
       (localStorage.getItem('theme') as 'light' | 'dark') ||
       (window.matchMedia('(prefers-color-scheme: dark)').matches
@@ -96,6 +100,16 @@ export const useWorkflowStore = create<WorkflowState>()(
     setSelected: (ids) =>
       set((s) => {
         s.selected = ids;
+      }),
+
+    openEditor: (id) =>
+      set((s) => {
+        s.editing = id;
+      }),
+
+    closeEditor: () =>
+      set((s) => {
+        s.editing = null;
       }),
 
     updateNodeField: (uuid, fieldId, value) =>

--- a/src/theme.css
+++ b/src/theme.css
@@ -40,6 +40,7 @@
   border-radius: 6px;
   font-size: 12px;
   min-width: 120px;
+  position: relative;
 }
 
 /* Each row in the node */
@@ -123,4 +124,18 @@
   border-radius: 6px;
   z-index: 10;
   min-width: 240px;
+}
+
+/* Edit button overlay */
+.edit-btn {
+  position: absolute;
+  bottom: 2px;
+  right: 2px;
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  font-size: 10px;
+  padding: 2px 4px;
+  cursor: pointer;
 }

--- a/src/theme.css
+++ b/src/theme.css
@@ -128,7 +128,7 @@
 
 /* Edit button row */
 .edit-row {
-  justify-content: flex-end;
+  justify-content: center;
 }
 .edit-btn {
   background: var(--accent);
@@ -138,4 +138,61 @@
   font-size: 10px;
   padding: 2px 4px;
   cursor: pointer;
+}
+
+/* Properties panel fields */
+.field-label {
+  display: block;
+  margin-bottom: 0.5rem;
+}
+.field-label > input,
+.field-label > select {
+  display: block;
+  margin-top: 0.25rem;
+  width: 100%;
+}
+.field-label > .switch {
+  display: block;
+  margin-top: 0.25rem;
+}
+
+/* Toggle switch */
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 34px;
+  height: 18px;
+}
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: #ccc;
+  transition: 0.2s;
+  border-radius: 18px;
+}
+.slider:before {
+  position: absolute;
+  content: '';
+  height: 14px;
+  width: 14px;
+  left: 2px;
+  bottom: 2px;
+  background: white;
+  transition: 0.2s;
+  border-radius: 50%;
+}
+.switch input:checked + .slider {
+  background: var(--accent);
+}
+.switch input:checked + .slider:before {
+  transform: translateX(16px);
 }

--- a/src/theme.css
+++ b/src/theme.css
@@ -103,3 +103,24 @@
   margin-right: 12px;
   text-align: right;
 }
+
+/* Modal styles */
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: #0006;
+  z-index: 5;
+}
+.modal {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid var(--accent);
+  padding: 1rem;
+  border-radius: 6px;
+  z-index: 10;
+  min-width: 240px;
+}

--- a/src/theme.css
+++ b/src/theme.css
@@ -126,11 +126,11 @@
   min-width: 240px;
 }
 
-/* Edit button overlay */
+/* Edit button row */
+.edit-row {
+  justify-content: flex-end;
+}
 .edit-btn {
-  position: absolute;
-  bottom: 2px;
-  right: 2px;
   background: var(--accent);
   color: #fff;
   border: none;

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,7 @@ export interface Field {
   id: string;
   name: string;
   label: string;
-  type: 'string' | 'number' | 'boolean' | 'enum';
+  type: 'string' | 'integer' | 'float' | 'bool' | 'enum';
   required?: boolean;
   options?: string[];        // for enum
   default?: unknown;


### PR DESCRIPTION
## Summary
- support extended field types in `Field`
- update node type definitions with example data types
- implement `setSelected`, `updateNodeField` and `moveNode` in the store
- update ReactFlow canvas to track selection and node positions
- replace PropertiesPanel with a modal popup that renders inputs based on field type
- add modal styling

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684702ac02bc83278d738892089f9d5a