### PR TITLE
Implement node & edge context menu actions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,6 @@ import NodePalette from './components/NodePalette';
 import EditorCanvas from './components/EditorCanvas';
 import PropertiesPanel from './components/PropertiesPanel';
 import ErrorToast from './components/ErrorToast';
-import ContextMenu from './components/ContextMenu';
 import clsx from 'clsx';
 
 export default function App() {
@@ -22,7 +21,6 @@ export default function App() {
     <div className={clsx('app', theme)}>
       <NodePalette />
       <EditorCanvas />
-      <ContextMenu />
       <PropertiesPanel />
       <ErrorToast />
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,9 +11,13 @@ export default function App() {
   const loadDefs  = useWorkflowStore((s) => s.loadDefinitions);
 
   useEffect(() => {
+    console.log('Fetching node types...');
     fetch(`${import.meta.env.BASE_URL}nodeTypes.json`)
       .then((r) => r.json())
-      .then(loadDefs)
+      .then((json) => {
+        console.log('Node types loaded');
+        loadDefs(json);
+      })
       .catch((err) => console.error('Failed to load node types', err));
   }, []);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import NodePalette from './components/NodePalette';
 import EditorCanvas from './components/EditorCanvas';
 import PropertiesPanel from './components/PropertiesPanel';
 import ErrorToast from './components/ErrorToast';
+import ContextMenu from './components/ContextMenu';
 import clsx from 'clsx';
 
 export default function App() {
@@ -21,6 +22,7 @@ export default function App() {
     <div className={clsx('app', theme)}>
       <NodePalette />
       <EditorCanvas />
+      <ContextMenu />
       <PropertiesPanel />
       <ErrorToast />
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,13 +11,9 @@ export default function App() {
   const loadDefs  = useWorkflowStore((s) => s.loadDefinitions);
 
   useEffect(() => {
-    console.log('Fetching node types...');
     fetch(`${import.meta.env.BASE_URL}nodeTypes.json`)
       .then((r) => r.json())
-      .then((json) => {
-        console.log('Node types loaded');
-        loadDefs(json);
-      })
+      .then(loadDefs)
       .catch((err) => console.error('Failed to load node types', err));
   }, []);
 

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -1,0 +1,38 @@
+import { useWorkflowStore } from '../store/workflowStore';
+
+export default function ContextMenu() {
+  const menu = useWorkflowStore((s) => s.contextMenu);
+  const setMenu = useWorkflowStore((s) => s.openContextMenu);
+  const removeNode = useWorkflowStore((s) => s.removeNode);
+  const duplicateNode = useWorkflowStore((s) => s.duplicateNode);
+  const removeEdge = useWorkflowStore((s) => s.removeEdge);
+
+  if (!menu) return null;
+
+  const onDelete = () => {
+    if (menu.type === 'node') {
+      removeNode(menu.id);
+    } else {
+      removeEdge(menu.id);
+    }
+    setMenu(null);
+  };
+
+  const onDuplicate = () => {
+    if (menu.type === 'node') {
+      duplicateNode(menu.id);
+    }
+    setMenu(null);
+  };
+
+  return (
+    <ul
+      className="context-menu"
+      style={{ position: 'absolute', top: menu.position.y, left: menu.position.x, zIndex: 20 }}
+      onContextMenu={(e) => e.preventDefault()}
+    >
+      {menu.type === 'node' && <li onClick={onDuplicate}>Duplicate Node</li>}
+      <li onClick={onDelete}>Delete {menu.type === 'node' ? 'Node' : 'Connection'}</li>
+    </ul>
+  );
+}

--- a/src/components/CustomNode.tsx
+++ b/src/components/CustomNode.tsx
@@ -23,7 +23,12 @@ export default function CustomNode({ data, selected }: NodeProps<RFNode>) {
 
   return (
     <div className="custom-node">
-      <NodeToolbar className="node-toolbar" isVisible={selected} position={Position.Top} align="center">
+      <NodeToolbar
+        className="node-toolbar"
+        isVisible={selected}
+        position={Position.Bottom}
+        align="center"
+      >
         <button onClick={() => duplicateNode(nodeInst.uuid)} aria-label="Duplicate">⧉</button>
         <button onClick={() => removeNode(nodeInst.uuid)} aria-label="Delete">🗑️</button>
       </NodeToolbar>

--- a/src/components/CustomNode.tsx
+++ b/src/components/CustomNode.tsx
@@ -1,5 +1,6 @@
 // src/components/CustomNode.tsx
 import { Handle, Node, NodeProps, Position, NodeToolbar } from '@xyflow/react';
+import { useState } from 'react';
 import { useWorkflowStore } from '../store/workflowStore';
 import type { NodeInstance } from '../types';
 
@@ -12,7 +13,7 @@ export type RFNode = Node<CustomData>;
  *  - one row per input (handle left + label)
  *  - one row per output (label + handle right)
  */
-export default function CustomNode({ data, selected }: NodeProps<RFNode>) {
+export default function CustomNode({ data }: NodeProps<RFNode>) {
   const nodeInst = data.node;
   const nodeType = useWorkflowStore(
     (s) => s.nodeTypes.find((nt) => nt.id === nodeInst.nodeTypeId)!
@@ -20,17 +21,22 @@ export default function CustomNode({ data, selected }: NodeProps<RFNode>) {
   const openEditor = useWorkflowStore((s) => s.openEditor);
   const removeNode = useWorkflowStore((s) => s.removeNode);
   const duplicateNode = useWorkflowStore((s) => s.duplicateNode);
+  const [hovered, setHovered] = useState(false);
 
   return (
-    <div className="custom-node">
+    <div
+      className="custom-node"
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
       <NodeToolbar
         className="node-toolbar"
-        isVisible={selected}
+        isVisible={hovered}
         position={Position.Bottom}
         align="center"
       >
         <button onClick={() => duplicateNode(nodeInst.uuid)} aria-label="Duplicate">⧉</button>
-        <button onClick={() => removeNode(nodeInst.uuid)} aria-label="Delete">🗑️</button>
+        <button onClick={() => removeNode(nodeInst.uuid)} aria-label="Delete">✖</button>
       </NodeToolbar>
       {/* Title row */}
       <div className="node-row title">

--- a/src/components/CustomNode.tsx
+++ b/src/components/CustomNode.tsx
@@ -1,6 +1,6 @@
 // src/components/CustomNode.tsx
 import { Handle, Node, NodeProps, Position, NodeToolbar } from '@xyflow/react';
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { useWorkflowStore } from '../store/workflowStore';
 import type { NodeInstance } from '../types';
 
@@ -22,12 +22,31 @@ export default function CustomNode({ data }: NodeProps<RFNode>) {
   const removeNode = useWorkflowStore((s) => s.removeNode);
   const duplicateNode = useWorkflowStore((s) => s.duplicateNode);
   const [hovered, setHovered] = useState(false);
+  const hideTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const show = () => {
+    if (hideTimer.current) {
+      clearTimeout(hideTimer.current);
+      hideTimer.current = null;
+    }
+    setHovered(true);
+  };
+
+  const hide = () => {
+    if (hideTimer.current) {
+      clearTimeout(hideTimer.current);
+    }
+    hideTimer.current = setTimeout(() => {
+      setHovered(false);
+      hideTimer.current = null;
+    }, 150);
+  };
 
   return (
     <div
       className="custom-node"
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
+      onMouseEnter={show}
+      onMouseLeave={hide}
     >
       <NodeToolbar
         className="node-toolbar"
@@ -35,8 +54,8 @@ export default function CustomNode({ data }: NodeProps<RFNode>) {
         position={Position.Bottom}
         align="center"
         offset={4}
-        onMouseEnter={() => setHovered(true)}
-        onMouseLeave={() => setHovered(false)}
+        onMouseEnter={show}
+        onMouseLeave={hide}
       >
         <button onClick={() => duplicateNode(nodeInst.uuid)} aria-label="Duplicate">⧉</button>
         <button onClick={() => removeNode(nodeInst.uuid)} aria-label="Delete">✖</button>

--- a/src/components/CustomNode.tsx
+++ b/src/components/CustomNode.tsx
@@ -34,6 +34,9 @@ export default function CustomNode({ data }: NodeProps<RFNode>) {
         isVisible={hovered}
         position={Position.Bottom}
         align="center"
+        offset={4}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
       >
         <button onClick={() => duplicateNode(nodeInst.uuid)} aria-label="Duplicate">⧉</button>
         <button onClick={() => removeNode(nodeInst.uuid)} aria-label="Delete">✖</button>

--- a/src/components/CustomNode.tsx
+++ b/src/components/CustomNode.tsx
@@ -1,5 +1,5 @@
 // src/components/CustomNode.tsx
-import { Handle, Node, NodeProps, Position } from '@xyflow/react';
+import { Handle, Node, NodeProps, Position, NodeToolbar } from '@xyflow/react';
 import { useWorkflowStore } from '../store/workflowStore';
 import type { NodeInstance } from '../types';
 
@@ -12,15 +12,21 @@ export type RFNode = Node<CustomData>;
  *  - one row per input (handle left + label)
  *  - one row per output (label + handle right)
  */
-export default function CustomNode({ data }: NodeProps<RFNode>) {
+export default function CustomNode({ data, selected }: NodeProps<RFNode>) {
   const nodeInst = data.node;
   const nodeType = useWorkflowStore(
     (s) => s.nodeTypes.find((nt) => nt.id === nodeInst.nodeTypeId)!
   );
   const openEditor = useWorkflowStore((s) => s.openEditor);
+  const removeNode = useWorkflowStore((s) => s.removeNode);
+  const duplicateNode = useWorkflowStore((s) => s.duplicateNode);
 
   return (
     <div className="custom-node">
+      <NodeToolbar className="node-toolbar" isVisible={selected} position={Position.Top} align="center">
+        <button onClick={() => duplicateNode(nodeInst.uuid)} aria-label="Duplicate">⧉</button>
+        <button onClick={() => removeNode(nodeInst.uuid)} aria-label="Delete">🗑️</button>
+      </NodeToolbar>
       {/* Title row */}
       <div className="node-row title">
         {nodeType.icon && <img src={nodeType.icon} alt="" className="icon" />}

--- a/src/components/DeletableEdge.tsx
+++ b/src/components/DeletableEdge.tsx
@@ -1,0 +1,35 @@
+import { BaseEdge, EdgeLabelRenderer, EdgeProps, getBezierPath } from '@xyflow/react';
+import { useWorkflowStore } from '../store/workflowStore';
+
+export default function DeletableEdge({ id, sourceX, sourceY, targetX, targetY, sourcePosition, targetPosition, markerEnd, style, selected }: EdgeProps) {
+  const removeEdge = useWorkflowStore((s) => s.removeEdge);
+  const [edgePath, labelX, labelY] = getBezierPath({
+    sourceX,
+    sourceY,
+    sourcePosition,
+    targetX,
+    targetY,
+    targetPosition,
+  });
+
+  return (
+    <>
+      <BaseEdge id={id} path={edgePath} markerEnd={markerEnd} style={style} />
+      <EdgeLabelRenderer>
+        <button
+          className="edge-delete-btn"
+          style={{
+            display: selected ? 'block' : 'none',
+            position: 'absolute',
+            transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+            pointerEvents: 'all',
+          }}
+          onClick={() => removeEdge(id)}
+          aria-label="Delete"
+        >
+          🗑️
+        </button>
+      </EdgeLabelRenderer>
+    </>
+  );
+}

--- a/src/components/DeletableEdge.tsx
+++ b/src/components/DeletableEdge.tsx
@@ -1,8 +1,10 @@
 import { BaseEdge, EdgeLabelRenderer, EdgeProps, getBezierPath } from '@xyflow/react';
 import { useWorkflowStore } from '../store/workflowStore';
+import { useState } from 'react';
 
 export default function DeletableEdge({ id, sourceX, sourceY, targetX, targetY, sourcePosition, targetPosition, markerEnd, style, selected }: EdgeProps) {
   const removeEdge = useWorkflowStore((s) => s.removeEdge);
+  const [hovered, setHovered] = useState(false);
   const [edgePath, labelX, labelY] = getBezierPath({
     sourceX,
     sourceY,
@@ -14,20 +16,29 @@ export default function DeletableEdge({ id, sourceX, sourceY, targetX, targetY, 
 
   return (
     <>
-      <BaseEdge id={id} path={edgePath} markerEnd={markerEnd} style={style} />
+      <BaseEdge
+        id={id}
+        path={edgePath}
+        markerEnd={markerEnd}
+        style={style}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+      />
       <EdgeLabelRenderer>
         <button
           className="edge-delete-btn"
           style={{
-            display: selected ? 'block' : 'none',
+            display: hovered || selected ? 'block' : 'none',
             position: 'absolute',
             transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
             pointerEvents: 'all',
           }}
+          onMouseEnter={() => setHovered(true)}
+          onMouseLeave={() => setHovered(false)}
           onClick={() => removeEdge(id)}
           aria-label="Delete"
         >
-          🗑️
+          ✖
         </button>
       </EdgeLabelRenderer>
     </>

--- a/src/components/EditorCanvas.tsx
+++ b/src/components/EditorCanvas.tsx
@@ -58,6 +58,7 @@ function FlowInner() {
   const syncingRef = useRef(false);
 
   useEffect(() => {
+    console.log('Sync nodes from store', Object.keys(storeNodes));
     setNodes(
       Object.values(storeNodes).map((n) => ({
         id: n.uuid,
@@ -69,6 +70,7 @@ function FlowInner() {
   }, [storeNodes, setNodes]);
 
   useEffect(() => {
+    console.log('Sync edges from store', storeEdges);
     syncingRef.current = true;
     setEdges(
       storeEdges.map((e) => ({
@@ -87,6 +89,7 @@ function FlowInner() {
 
   const handleNodesChange = useCallback(
     (changes: NodeChange[]) => {
+      console.log('Nodes change', changes);
       changes.forEach((c) => {
         if (c.type === 'position' && c.position) {
           moveNode(c.id as string, c.position);
@@ -161,9 +164,11 @@ function FlowInner() {
         onNodesChange={handleNodesChange}
         onEdgesChange={(changes) => {
           if (syncingRef.current) {
+            console.log('Skip edgesChange due to syncingRef', changes);
             syncingRef.current = false;
             return;
           }
+          console.log('Edges change', changes);
           changes.forEach((c) => c.type === 'remove' && removeEdge(c.id as string));
           onEdgesChange(changes);
         }}
@@ -171,14 +176,17 @@ function FlowInner() {
         onDrop={onDrop}
         onDragOver={onDragOver}
         onSelectionChange={(sel) => {
+          console.log('Selection change', sel);
           setSelected(sel.nodes.map((n) => n.id));
         }}
         onNodeContextMenu={(e, node) => {
           e.preventDefault();
+          console.log('Node context menu', node);
           setSelected([node.id as string]);
         }}
         onEdgeContextMenu={(e, edge) => {
           e.preventDefault();
+          console.log('Edge context menu', edge);
           syncingRef.current = true;
           setEdges((eds) =>
             eds.map((el) => ({ ...el, selected: el.id === edge.id }))

--- a/src/components/EditorCanvas.tsx
+++ b/src/components/EditorCanvas.tsx
@@ -40,6 +40,7 @@ export default function EditorCanvas() {
 /*  INNER: all React-Flow hooks live here                                     */
 /* -------------------------------------------------------------------------- */
 function FlowInner() {
+  console.log('FlowInner mount');
   /* -------- zustand store bindings --------------------------------------- */
   const storeNodes = useWorkflowStore((s) => s.nodes);
   const storeEdges = useWorkflowStore((s) => s.edges);
@@ -59,6 +60,7 @@ function FlowInner() {
 
   useEffect(() => {
     console.log('Sync nodes from store', Object.keys(storeNodes));
+    console.trace('setNodes from store');
     setNodes(
       Object.values(storeNodes).map((n) => ({
         id: n.uuid,
@@ -72,6 +74,7 @@ function FlowInner() {
   useEffect(() => {
     console.log('Sync edges from store', storeEdges);
     syncingRef.current = true;
+    console.trace('setEdges from store');
     setEdges(
       storeEdges.map((e) => ({
         id: e.id,
@@ -103,6 +106,7 @@ function FlowInner() {
   const onDrop = useCallback(
     (evt: React.DragEvent) => {
       evt.preventDefault();
+      console.log('onDrop', evt.clientX, evt.clientY);
       const typeId = evt.dataTransfer.getData('application/x-node-type');
       if (!typeId) return;
 
@@ -115,11 +119,13 @@ function FlowInner() {
   const onDragOver = useCallback((e: React.DragEvent) => {
     e.preventDefault();
     e.dataTransfer.dropEffect = 'move';
+    console.log('onDragOver');
   }, []);
 
   /* -------- connect pins -------------------------------------------------- */
   const onConnect = useCallback(
     (c: Connection) => {
+      console.log('onConnect', c);
       if (!c.source || !c.target || !c.sourceHandle || !c.targetHandle) return;
       const fromNode = storeNodes[c.source];
       const toNode = storeNodes[c.target];
@@ -169,6 +175,7 @@ function FlowInner() {
             return;
           }
           console.log('Edges change', changes);
+          console.trace('onEdgesChange triggered');
           changes.forEach((c) => c.type === 'remove' && removeEdge(c.id as string));
           onEdgesChange(changes);
         }}
@@ -188,6 +195,7 @@ function FlowInner() {
           e.preventDefault();
           console.log('Edge context menu', edge);
           syncingRef.current = true;
+          console.trace('setEdges from context menu');
           setEdges((eds) =>
             eds.map((el) => ({ ...el, selected: el.id === edge.id }))
           );

--- a/src/components/EditorCanvas.tsx
+++ b/src/components/EditorCanvas.tsx
@@ -166,9 +166,6 @@ function FlowInner() {
         onDragOver={onDragOver}
         onSelectionChange={(sel) => {
           setSelected(sel.nodes.map((n) => n.id));
-          setEdges((eds) =>
-            eds.map((e) => ({ ...e, selected: sel.edges.some((se) => se.id === e.id) }))
-          );
         }}
         onNodeContextMenu={(e, node) => {
           e.preventDefault();

--- a/src/components/EditorCanvas.tsx
+++ b/src/components/EditorCanvas.tsx
@@ -40,7 +40,6 @@ export default function EditorCanvas() {
 /*  INNER: all React-Flow hooks live here                                     */
 /* -------------------------------------------------------------------------- */
 function FlowInner() {
-  console.log('FlowInner mount');
   /* -------- zustand store bindings --------------------------------------- */
   const storeNodes = useWorkflowStore((s) => s.nodes);
   const storeEdges = useWorkflowStore((s) => s.edges);
@@ -59,8 +58,6 @@ function FlowInner() {
   const syncingRef = useRef(false);
 
   useEffect(() => {
-    console.log('Sync nodes from store', Object.keys(storeNodes));
-    console.trace('setNodes from store');
     setNodes(
       Object.values(storeNodes).map((n) => ({
         id: n.uuid,
@@ -72,9 +69,7 @@ function FlowInner() {
   }, [storeNodes, setNodes]);
 
   useEffect(() => {
-    console.log('Sync edges from store', storeEdges);
     syncingRef.current = true;
-    console.trace('setEdges from store');
     setEdges(
       storeEdges.map((e) => ({
         id: e.id,
@@ -92,7 +87,6 @@ function FlowInner() {
 
   const handleNodesChange = useCallback(
     (changes: NodeChange[]) => {
-      console.log('Nodes change', changes);
       changes.forEach((c) => {
         if (c.type === 'position' && c.position) {
           moveNode(c.id as string, c.position);
@@ -106,7 +100,6 @@ function FlowInner() {
   const onDrop = useCallback(
     (evt: React.DragEvent) => {
       evt.preventDefault();
-      console.log('onDrop', evt.clientX, evt.clientY);
       const typeId = evt.dataTransfer.getData('application/x-node-type');
       if (!typeId) return;
 
@@ -119,13 +112,11 @@ function FlowInner() {
   const onDragOver = useCallback((e: React.DragEvent) => {
     e.preventDefault();
     e.dataTransfer.dropEffect = 'move';
-    console.log('onDragOver');
   }, []);
 
   /* -------- connect pins -------------------------------------------------- */
   const onConnect = useCallback(
     (c: Connection) => {
-      console.log('onConnect', c);
       if (!c.source || !c.target || !c.sourceHandle || !c.targetHandle) return;
       const fromNode = storeNodes[c.source];
       const toNode = storeNodes[c.target];
@@ -170,12 +161,9 @@ function FlowInner() {
         onNodesChange={handleNodesChange}
         onEdgesChange={(changes) => {
           if (syncingRef.current) {
-            console.log('Skip edgesChange due to syncingRef', changes);
             syncingRef.current = false;
             return;
           }
-          console.log('Edges change', changes);
-          console.trace('onEdgesChange triggered');
           changes.forEach((c) => c.type === 'remove' && removeEdge(c.id as string));
           onEdgesChange(changes);
         }}
@@ -183,19 +171,15 @@ function FlowInner() {
         onDrop={onDrop}
         onDragOver={onDragOver}
         onSelectionChange={(sel) => {
-          console.log('Selection change', sel);
           setSelected(sel.nodes.map((n) => n.id));
         }}
         onNodeContextMenu={(e, node) => {
           e.preventDefault();
-          console.log('Node context menu', node);
           setSelected([node.id as string]);
         }}
         onEdgeContextMenu={(e, edge) => {
           e.preventDefault();
-          console.log('Edge context menu', edge);
           syncingRef.current = true;
-          console.trace('setEdges from context menu');
           setEdges((eds) =>
             eds.map((el) => ({ ...el, selected: el.id === edge.id }))
           );

--- a/src/components/EditorCanvas.tsx
+++ b/src/components/EditorCanvas.tsx
@@ -46,6 +46,7 @@ function FlowInner() {
   const removeEdge = useWorkflowStore((s) => s.removeEdge);
   const moveNode = useWorkflowStore((s) => s.moveNode);
   const setSelected = useWorkflowStore((s) => s.setSelected);
+  const openContextMenu = useWorkflowStore((s) => s.openContextMenu);
 
   const nodeDefs = useWorkflowStore((s) => s.nodeTypes);
   const hierarchy = useWorkflowStore((s) => s.typeHierarchy);
@@ -161,6 +162,23 @@ function FlowInner() {
         onDrop={onDrop}
         onDragOver={onDragOver}
         onSelectionChange={(sel) => setSelected(sel.nodes.map((n) => n.id))}
+        onNodeContextMenu={(e, node) => {
+          e.preventDefault();
+          openContextMenu({
+            type: 'node',
+            id: node.id as string,
+            position: { x: e.clientX, y: e.clientY }
+          });
+        }}
+        onEdgeContextMenu={(e, edge) => {
+          e.preventDefault();
+          openContextMenu({
+            type: 'edge',
+            id: edge.id as string,
+            position: { x: e.clientX, y: e.clientY }
+          });
+        }}
+        onPaneClick={() => openContextMenu(null)}
         fitView
       >
         <Background />

--- a/src/store/workflowStore.ts
+++ b/src/store/workflowStore.ts
@@ -74,6 +74,7 @@ export const useWorkflowStore = create<WorkflowState>()(
 
     addNode: (typeId, position) =>
       set((s) => {
+        console.log('addNode', typeId, position);
         const id = uuid();
         s.nodes[id] = {
           uuid: id,
@@ -85,6 +86,7 @@ export const useWorkflowStore = create<WorkflowState>()(
 
     duplicateNode: (origId) =>
       set((s) => {
+        console.log('duplicateNode', origId);
         const orig = s.nodes[origId];
         if (!orig) return;
         const id = uuid();
@@ -98,6 +100,7 @@ export const useWorkflowStore = create<WorkflowState>()(
 
     removeNode: (id) =>
       set((s) => {
+        console.log('removeNode', id);
         delete s.nodes[id];
         s.edges = s.edges.filter(
           (e) => e.from.uuid !== id && e.to.uuid !== id
@@ -106,16 +109,19 @@ export const useWorkflowStore = create<WorkflowState>()(
 
     addEdge: (edge) =>
       set((s) => {
+        console.log('addEdge', edge);
         s.edges.push(edge);
       }),
 
     removeEdge: (id) =>
       set((s) => {
+        console.log('removeEdge', id);
         s.edges = s.edges.filter((e) => e.id !== id);
       }),
 
     openContextMenu: (menu) =>
       set((s) => {
+        console.log('openContextMenu', menu);
         s.contextMenu = menu;
       }),
 

--- a/src/store/workflowStore.ts
+++ b/src/store/workflowStore.ts
@@ -68,6 +68,7 @@ export const useWorkflowStore = create<WorkflowState>()(
 
     loadDefinitions: (json) =>
       set((s) => {
+        console.log('loadDefinitions', json);
         s.nodeTypes = json.nodes;
         s.typeHierarchy = json.types;
       }),

--- a/src/store/workflowStore.ts
+++ b/src/store/workflowStore.ts
@@ -68,14 +68,12 @@ export const useWorkflowStore = create<WorkflowState>()(
 
     loadDefinitions: (json) =>
       set((s) => {
-        console.log('loadDefinitions', json);
         s.nodeTypes = json.nodes;
         s.typeHierarchy = json.types;
       }),
 
     addNode: (typeId, position) =>
       set((s) => {
-        console.log('addNode', typeId, position);
         const id = uuid();
         s.nodes[id] = {
           uuid: id,
@@ -87,7 +85,6 @@ export const useWorkflowStore = create<WorkflowState>()(
 
     duplicateNode: (origId) =>
       set((s) => {
-        console.log('duplicateNode', origId);
         const orig = s.nodes[origId];
         if (!orig) return;
         const id = uuid();
@@ -101,7 +98,6 @@ export const useWorkflowStore = create<WorkflowState>()(
 
     removeNode: (id) =>
       set((s) => {
-        console.log('removeNode', id);
         delete s.nodes[id];
         s.edges = s.edges.filter(
           (e) => e.from.uuid !== id && e.to.uuid !== id
@@ -110,19 +106,16 @@ export const useWorkflowStore = create<WorkflowState>()(
 
     addEdge: (edge) =>
       set((s) => {
-        console.log('addEdge', edge);
         s.edges.push(edge);
       }),
 
     removeEdge: (id) =>
       set((s) => {
-        console.log('removeEdge', id);
         s.edges = s.edges.filter((e) => e.id !== id);
       }),
 
     openContextMenu: (menu) =>
       set((s) => {
-        console.log('openContextMenu', menu);
         s.contextMenu = menu;
       }),
 

--- a/src/theme.css
+++ b/src/theme.css
@@ -222,10 +222,10 @@
   color: #fff;
   border: none;
   border-radius: 4px;
-  width: 24px;
-  height: 24px;
-  font-size: 16px;
-  margin: 0 2px;
+  width: 28px;
+  height: 28px;
+  font-size: 18px;
+  margin: 0 3px;
   cursor: pointer;
 }
 
@@ -235,8 +235,8 @@
   border: none;
   color: #fff;
   border-radius: 50%;
-  width: 24px;
-  height: 24px;
+  width: 28px;
+  height: 28px;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/theme.css
+++ b/src/theme.css
@@ -221,10 +221,10 @@
   background: var(--accent);
   color: #fff;
   border: none;
-  border-radius: 3px;
-  width: 18px;
-  height: 18px;
-  font-size: 12px;
+  border-radius: 4px;
+  width: 24px;
+  height: 24px;
+  font-size: 16px;
   margin: 0 2px;
   cursor: pointer;
 }
@@ -235,8 +235,8 @@
   border: none;
   color: #fff;
   border-radius: 50%;
-  width: 20px;
-  height: 20px;
+  width: 24px;
+  height: 24px;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/theme.css
+++ b/src/theme.css
@@ -215,3 +215,30 @@
   background: var(--accent);
   color: #fff;
 }
+
+/* Node action toolbar */
+.react-flow__node-toolbar button {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 3px;
+  width: 18px;
+  height: 18px;
+  font-size: 12px;
+  margin: 0 2px;
+  cursor: pointer;
+}
+
+/* Edge delete button */
+.edge-delete-btn {
+  background: var(--accent);
+  border: none;
+  color: #fff;
+  border-radius: 50%;
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}

--- a/src/theme.css
+++ b/src/theme.css
@@ -196,3 +196,22 @@
 .switch input:checked + .slider:before {
   transform: translateX(16px);
 }
+
+/* Context menu */
+.context-menu {
+  list-style: none;
+  margin: 0;
+  padding: 4px 0;
+  background: var(--bg);
+  border: 1px solid var(--accent);
+  border-radius: 4px;
+  font-size: 12px;
+}
+.context-menu li {
+  padding: 2px 12px;
+  cursor: pointer;
+}
+.context-menu li:hover {
+  background: var(--accent);
+  color: #fff;
+}


### PR DESCRIPTION
## Summary
- support duplicate/delete node and remove connection via context menu
- wire up context menu to nodes and edges on the canvas
- style context menu

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68470c6d87588327b8e08c04f2f3e39a