### PR TITLE
Add MCP tool and refine tool output types

### DIFF
--- a/public/nodeTypes.json
+++ b/public/nodeTypes.json
@@ -4,7 +4,10 @@
     "OpenAIChatModel": "ChatModel",
     "Tool": null,
     "State": null,
-    "Text": null
+    "Text": null,
+    "WebSearch": "Tool",
+    "Calculator": "Tool",
+    "MCP": "Tool"
   },
   "nodes": [
     {
@@ -149,7 +152,7 @@
           "id": "toolOut",
           "name": "Tool",
           "direction": "output",
-          "type": "Tool",
+          "type": "WebSearch",
           "cardinality": "many"
         }
       ],
@@ -166,7 +169,24 @@
           "id": "toolOut",
           "name": "Tool",
           "direction": "output",
-          "type": "Tool",
+          "type": "Calculator",
+          "cardinality": "many"
+        }
+      ],
+      "fields": []
+    },
+    {
+      "id": "tool.mcp",
+      "name": "MCP Tool",
+      "tags": ["tool", "mcp"],
+      "layout": "singleRow",
+      "inputs": [],
+      "outputs": [
+        {
+          "id": "toolOut",
+          "name": "Tool",
+          "direction": "output",
+          "type": "MCP",
           "cardinality": "many"
         }
       ],


### PR DESCRIPTION
## Summary
- add `MCP` tool node and derive new tool types from `Tool`
- use specific tool types for Web Search and Calculator nodes
- extend the `types` section with `WebSearch`, `Calculator`, and `MCP`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68473ab9866c8327b579c59dd8c6835d