### PR TITLE
Add chat page with history sidebar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ This project implements a visual node editor for building AI workflows. The arch
   - `CustomNode.tsx` – Renders nodes using the single-row layout and exposes an edit button.
   - `PropertiesPanel.tsx` – Modal editor for the selected node's fields.
   - `ErrorToast.tsx` – Transient error display.
+  - `ChatPage.tsx` – Standalone chat interface with collapsible history.
 - **store/workflowStore.ts** – Zustand store implementing the workflow state model and localStorage persistence.
 - **logic/pinValidation.ts** – Implements connection and workflow validation (tested).
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,9 @@ export default function App() {
     'workflows' | 'editor' | 'settings' | 'tools' | 'assistants' | 'chat'
   >('workflows');
   const [returnPage, setReturnPage] = useState<'workflows' | 'tools'>('workflows');
+  const [chatBack, setChatBack] = useState<
+    'workflows' | 'settings' | 'tools' | 'assistants'
+  >('workflows');
 
   useEffect(() => {
     fetch(`${import.meta.env.BASE_URL}nodeTypes.json`)
@@ -53,7 +56,7 @@ export default function App() {
 
   return (
     <div className={clsx('app-container', theme)}>
-      {page !== 'editor' && (
+      {page !== 'editor' && page !== 'chat' && (
         <Sidebar
           current={page as
             | 'workflows'
@@ -61,7 +64,14 @@ export default function App() {
             | 'tools'
             | 'assistants'
             | 'chat'}
-          onNavigate={setPage}
+          onNavigate={(p) => {
+            if (p === 'chat') {
+              setChatBack(
+                page as 'workflows' | 'settings' | 'tools' | 'assistants'
+              );
+            }
+            setPage(p);
+          }}
         />
       )}
 
@@ -72,7 +82,7 @@ export default function App() {
       )}
 
       {page === 'assistants' && <AssistantsPage />}
-      {page === 'chat' && <ChatPage />}
+      {page === 'chat' && <ChatPage onBack={() => setPage(chatBack)} />}
 
       {page === 'settings' && <SettingsPage />}
       {page === 'tools' && <ToolsPage onOpen={openTool} />}

--- a/src/components/ChatPage.tsx
+++ b/src/components/ChatPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import clsx from 'clsx';
 
 interface Message {
@@ -17,6 +17,7 @@ export default function ChatPage({ onBack }: { onBack: () => void }) {
   const [active, setActive] = useState<number | null>(null);
   const [input, setInput] = useState('');
   const [collapsed, setCollapsed] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 
   const deleteChat = (id: number) => {
     setChats((cs) => {
@@ -26,6 +27,14 @@ export default function ChatPage({ onBack }: { onBack: () => void }) {
       }
       return remaining;
     });
+  };
+
+  const resizeTextarea = () => {
+    const el = textareaRef.current;
+    if (el) {
+      el.style.height = 'auto';
+      el.style.height = `${el.scrollHeight}px`;
+    }
   };
 
   const createChat = () => {
@@ -54,6 +63,10 @@ export default function ChatPage({ onBack }: { onBack: () => void }) {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    resizeTextarea();
+  }, [input]);
 
   const messages = chats.find((c) => c.id === active)?.messages ?? [];
 
@@ -168,10 +181,15 @@ export default function ChatPage({ onBack }: { onBack: () => void }) {
           </div>
           {active !== null && (
             <form className="chat-input" onSubmit={sendMessage}>
-              <input
+              <textarea
+                ref={textareaRef}
                 value={input}
-                onChange={(e) => setInput(e.target.value)}
+                onInput={(e) => {
+                  setInput(e.currentTarget.value);
+                  resizeTextarea();
+                }}
                 placeholder="Type a message..."
+                rows={1}
               />
               <button type="submit">Send</button>
             </form>

--- a/src/components/ChatPage.tsx
+++ b/src/components/ChatPage.tsx
@@ -12,7 +12,7 @@ interface Chat {
   messages: Message[];
 }
 
-export default function ChatPage() {
+export default function ChatPage({ onBack }: { onBack: () => void }) {
   const [chats, setChats] = useState<Chat[]>([]);
   const [active, setActive] = useState<number | null>(null);
   const [input, setInput] = useState('');
@@ -48,9 +48,21 @@ export default function ChatPage() {
   const messages = chats.find((c) => c.id === active)?.messages ?? [];
 
   return (
-    <main className="main chat-page">
-      <div className="page-header">
-        <h2>Chat</h2>
+    <main className="main editor-page chat-page">
+      <div className="page-header editor-header">
+        <button className="back-btn" onClick={onBack} aria-label="Back">
+          <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
+            <polyline
+              points="15 18 9 12 15 6"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </button>
+        <h2 className="editor-title">Chat</h2>
       </div>
       <div className="chat-main">
         <aside className={clsx('chat-sidebar', { collapsed })}>

--- a/src/components/ChatPage.tsx
+++ b/src/components/ChatPage.tsx
@@ -32,8 +32,13 @@ export default function ChatPage({ onBack }: { onBack: () => void }) {
   const resizeTextarea = () => {
     const el = textareaRef.current;
     if (el) {
+      const style = getComputedStyle(el);
+      const line = parseFloat(style.lineHeight) || 20;
+      const pad =
+        parseFloat(style.paddingTop) + parseFloat(style.paddingBottom) || 0;
+      const max = line * 24 + pad; // limit to 24 lines
       el.style.height = 'auto';
-      el.style.height = `${el.scrollHeight}px`;
+      el.style.height = `${Math.min(el.scrollHeight, max)}px`;
     }
   };
 

--- a/src/components/ChatPage.tsx
+++ b/src/components/ChatPage.tsx
@@ -136,12 +136,22 @@ export default function ChatPage({ onBack }: { onBack: () => void }) {
                     type="button"
                     className="delete-btn"
                     title="Delete"
+                    aria-label="Delete"
                     onClick={(e) => {
                       e.stopPropagation();
                       deleteChat(chat.id);
                     }}
                   >
-                    🗑️
+                    <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
+                      <path
+                        d="M3 6h18M8 6v-1a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v1m1 0v12a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 4v6m4-6v6"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                    </svg>
                   </button>
                 </li>
               ))}

--- a/src/components/ChatPage.tsx
+++ b/src/components/ChatPage.tsx
@@ -1,8 +1,128 @@
+import { useState } from 'react';
+import clsx from 'clsx';
+
+interface Message {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+interface Chat {
+  id: number;
+  title: string;
+  messages: Message[];
+}
+
 export default function ChatPage() {
+  const [chats, setChats] = useState<Chat[]>([]);
+  const [active, setActive] = useState<number | null>(null);
+  const [input, setInput] = useState('');
+  const [collapsed, setCollapsed] = useState(false);
+
+  const createChat = () => {
+    const id = chats.length ? chats[chats.length - 1].id + 1 : 1;
+    const chat: Chat = { id, title: `Chat ${id}`, messages: [] };
+    setChats((c) => [...c, chat]);
+    setActive(id);
+  };
+
+  const sendMessage = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!input.trim() || active === null) return;
+    setChats((cs) =>
+      cs.map((c) =>
+        c.id === active
+          ? { ...c, messages: [...c.messages, { role: 'user', content: input }] }
+          : c
+      )
+    );
+    setInput('');
+  };
+
+  const messages = chats.find((c) => c.id === active)?.messages ?? [];
+
   return (
-    <main className="main">
-      <div className="page-header">
-        <h2>Chat</h2>
+    <main className="main chat-page">
+      <div className="page-header editor-header">
+        <h2 className="editor-title">Chat</h2>
+      </div>
+      <div className="chat-main">
+        <aside className={clsx('chat-sidebar', { collapsed })}>
+          <div className="chat-sidebar-header">
+            <button
+              type="button"
+              className="collapse-btn"
+              onClick={() => setCollapsed((c) => !c)}
+              aria-label={collapsed ? 'Expand' : 'Collapse'}
+            >
+              {collapsed ? '▶' : '◀'}
+            </button>
+            {!collapsed && (
+              <>
+                <h3 className="chat-history-title">History</h3>
+                <button
+                  type="button"
+                  className="create-btn"
+                  title="New Chat"
+                  onClick={createChat}
+                >
+                  <svg width="16" height="16" viewBox="0 0 12 12" aria-hidden="true">
+                    <line
+                      x1="1"
+                      y1="6"
+                      x2="11"
+                      y2="6"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                    />
+                    <line
+                      x1="6"
+                      y1="1"
+                      x2="6"
+                      y2="11"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                    />
+                  </svg>
+                  <span className="create-label">New</span>
+                </button>
+              </>
+            )}
+          </div>
+          {!collapsed && (
+            <ul className="chat-history-list">
+              {chats.map((chat) => (
+                <li
+                  key={chat.id}
+                  className={clsx('chat-history-item', { active: chat.id === active })}
+                  onClick={() => setActive(chat.id)}
+                >
+                  {chat.title}
+                </li>
+              ))}
+            </ul>
+          )}
+        </aside>
+        <section className="chat-window">
+          <div className="messages">
+            {messages.map((m, i) => (
+              <div key={i} className={clsx('message', m.role)}>
+                {m.content}
+              </div>
+            ))}
+          </div>
+          {active !== null && (
+            <form className="chat-input" onSubmit={sendMessage}>
+              <input
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                placeholder="Type a message..."
+              />
+              <button type="submit">Send</button>
+            </form>
+          )}
+        </section>
       </div>
     </main>
   );

--- a/src/components/ChatPage.tsx
+++ b/src/components/ChatPage.tsx
@@ -18,6 +18,16 @@ export default function ChatPage({ onBack }: { onBack: () => void }) {
   const [input, setInput] = useState('');
   const [collapsed, setCollapsed] = useState(false);
 
+  const deleteChat = (id: number) => {
+    setChats((cs) => {
+      const remaining = cs.filter((c) => c.id !== id);
+      if (active === id) {
+        setActive(remaining.length ? remaining[0].id : null);
+      }
+      return remaining;
+    });
+  };
+
   const createChat = () => {
     const id = chats.length ? chats[chats.length - 1].id + 1 : 1;
     const chat: Chat = { id, title: `Chat ${id}`, messages: [] };
@@ -115,9 +125,24 @@ export default function ChatPage({ onBack }: { onBack: () => void }) {
                 <li
                   key={chat.id}
                   className={clsx('chat-history-item', { active: chat.id === active })}
-                  onClick={() => setActive(chat.id)}
                 >
-                  {chat.title}
+                  <span
+                    className="chat-history-name"
+                    onClick={() => setActive(chat.id)}
+                  >
+                    {chat.title}
+                  </span>
+                  <button
+                    type="button"
+                    className="delete-btn"
+                    title="Delete"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      deleteChat(chat.id);
+                    }}
+                  >
+                    🗑️
+                  </button>
                 </li>
               ))}
             </ul>

--- a/src/components/ChatPage.tsx
+++ b/src/components/ChatPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import clsx from 'clsx';
 
 interface Message {
@@ -38,12 +38,19 @@ export default function ChatPage() {
     setInput('');
   };
 
+  useEffect(() => {
+    if (!chats.length) {
+      createChat();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const messages = chats.find((c) => c.id === active)?.messages ?? [];
 
   return (
     <main className="main chat-page">
-      <div className="page-header editor-header">
-        <h2 className="editor-title">Chat</h2>
+      <div className="page-header">
+        <h2>Chat</h2>
       </div>
       <div className="chat-main">
         <aside className={clsx('chat-sidebar', { collapsed })}>

--- a/src/theme.css
+++ b/src/theme.css
@@ -829,3 +829,113 @@ details[open] .field-summary .toggle-icon {
   margin-top: 2px;
 }
 
+/* Chat page */
+.chat-page {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 0;
+}
+
+.chat-main {
+  flex: 1;
+  display: flex;
+  height: 100%;
+}
+
+.chat-sidebar {
+  width: 200px;
+  border-right: 1px solid #6663;
+  display: flex;
+  flex-direction: column;
+  transition: width 0.2s;
+  overflow: hidden;
+}
+.chat-sidebar.collapsed {
+  width: 36px;
+}
+.chat-sidebar-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0.5rem;
+  border-bottom: 1px solid #6663;
+}
+.collapse-btn {
+  background: none;
+  border: none;
+  color: var(--fg);
+  cursor: pointer;
+  font-size: 1rem;
+}
+.chat-history-list {
+  list-style: none;
+  padding: 0.5rem;
+  margin: 0;
+  flex: 1;
+  overflow-y: auto;
+}
+.chat-history-item {
+  padding: 4px 6px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.chat-history-item:hover {
+  background: #6662;
+}
+.chat-history-item.active {
+  background: var(--accent);
+  color: #fff;
+}
+
+.chat-window {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 0.5rem;
+}
+.messages {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  overflow-y: auto;
+  padding-bottom: 0.5rem;
+}
+.message {
+  max-width: 60%;
+  padding: 4px 8px;
+  border-radius: 6px;
+}
+.message.user {
+  align-self: flex-end;
+  background: var(--accent);
+  color: #fff;
+}
+.message.assistant {
+  align-self: flex-start;
+  background: #6662;
+}
+.chat-input {
+  display: flex;
+  gap: 8px;
+  border-top: 1px solid #6663;
+  padding-top: 4px;
+}
+.chat-input input {
+  flex: 1;
+  padding: 4px;
+  border: 1px solid #6663;
+  border-radius: 4px;
+  background: var(--bg);
+  color: var(--fg);
+}
+.chat-input button {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  padding: 0 12px;
+  cursor: pointer;
+}
+

--- a/src/theme.css
+++ b/src/theme.css
@@ -936,7 +936,7 @@ details[open] .field-summary .toggle-icon {
   border-top: 1px solid #6663;
   padding-top: 8px;
 }
-.chat-input input {
+.chat-input textarea {
   flex: 1;
   padding: 8px;
   font-size: 1rem;
@@ -944,6 +944,8 @@ details[open] .field-summary .toggle-icon {
   border-radius: 4px;
   background: var(--bg);
   color: var(--fg);
+  resize: none;
+  overflow-y: auto;
 }
 .chat-input button {
   background: var(--accent);

--- a/src/theme.css
+++ b/src/theme.css
@@ -940,6 +940,8 @@ details[open] .field-summary .toggle-icon {
   flex: 1;
   padding: 8px;
   font-size: 1rem;
+  line-height: 20px;
+  max-height: 480px;
   border: 1px solid #6663;
   border-radius: 4px;
   background: var(--bg);

--- a/src/theme.css
+++ b/src/theme.css
@@ -768,6 +768,11 @@ details[open] .field-summary .toggle-icon {
   border: none;
   color: #d55;
   cursor: pointer;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 0;
 }
 
 /* Enum editing */

--- a/src/theme.css
+++ b/src/theme.css
@@ -929,11 +929,12 @@ details[open] .field-summary .toggle-icon {
   display: flex;
   gap: 8px;
   border-top: 1px solid #6663;
-  padding-top: 4px;
+  padding-top: 8px;
 }
 .chat-input input {
   flex: 1;
-  padding: 4px;
+  padding: 8px;
+  font-size: 1rem;
   border: 1px solid #6663;
   border-radius: 4px;
   background: var(--bg);
@@ -944,7 +945,8 @@ details[open] .field-summary .toggle-icon {
   color: #fff;
   border: none;
   border-radius: 4px;
-  padding: 0 12px;
+  padding: 8px 16px;
+  font-size: 1rem;
   cursor: pointer;
 }
 

--- a/src/theme.css
+++ b/src/theme.css
@@ -874,10 +874,19 @@ details[open] .field-summary .toggle-icon {
   margin: 0;
   flex: 1;
   overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 }
 .chat-history-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   padding: 4px 6px;
   border-radius: 4px;
+}
+.chat-history-name {
+  flex: 1;
   cursor: pointer;
 }
 .chat-history-item:hover {


### PR DESCRIPTION
## Summary
- build a real ChatPage component with collapsible sidebar
- style chat page in `theme.css`

## Testing
- `npm run verify`

------
https://chatgpt.com/codex/tasks/task_e_684b5f4594808327a9229a13d5c015d4