### PR TITLE
Add undo/redo for workflow editing

### DIFF
--- a/src/components/EditorCanvas.tsx
+++ b/src/components/EditorCanvas.tsx
@@ -47,6 +47,7 @@ function FlowInner() {
   const addEdgeStore = useWorkflowStore((s) => s.addEdge);
   const removeEdge = useWorkflowStore((s) => s.removeEdge);
   const moveNode = useWorkflowStore((s) => s.moveNode);
+  const recordSnapshot = useWorkflowStore((s) => s.recordSnapshot);
   const setSelected = useWorkflowStore((s) => s.setSelected);
 
   const nodeDefs = useWorkflowStore((s) => s.nodeTypes);
@@ -84,6 +85,7 @@ function FlowInner() {
 
   /* -------- drag-and-drop ------------------------------------------------- */
   const { screenToFlowPosition } = useReactFlow<RFNode, RFEdge>();
+  const dragRef = useRef(false);
 
   const handleNodesChange = useCallback(
     (changes: NodeChange[]) => {
@@ -96,6 +98,17 @@ function FlowInner() {
     },
     [onNodesChange, moveNode]
   );
+
+  const onNodeDragStart = useCallback(() => {
+    if (!dragRef.current) {
+      recordSnapshot();
+      dragRef.current = true;
+    }
+  }, [recordSnapshot]);
+
+  const onNodeDragStop = useCallback(() => {
+    dragRef.current = false;
+  }, []);
 
   const onDrop = useCallback(
     (evt: React.DragEvent) => {
@@ -159,6 +172,8 @@ function FlowInner() {
         nodeTypes={rfNodeTypes}
         edgeTypes={rfEdgeTypes}
         onNodesChange={handleNodesChange}
+        onNodeDragStart={onNodeDragStart}
+        onNodeDragStop={onNodeDragStop}
         onEdgesChange={(changes) => {
           if (syncingRef.current) {
             syncingRef.current = false;

--- a/src/components/EditorHeader.tsx
+++ b/src/components/EditorHeader.tsx
@@ -10,6 +10,8 @@ export default function EditorHeader({ onBack }: { onBack: () => void }) {
   const toolMeta = useWorkflowStore(s => s.toolMeta);
   const setToolMeta = useWorkflowStore(s => s.setToolMeta);
   const renameTool = useWorkflowStore(s => s.renameTool);
+  const undo = useWorkflowStore(s => s.undo);
+  const redo = useWorkflowStore(s => s.redo);
 
   const [editing, setEditing] = useState(false);
   const [newName, setNewName] = useState(displayName);
@@ -77,6 +79,48 @@ export default function EditorHeader({ onBack }: { onBack: () => void }) {
             />
           </svg>
         </button>
+        <div className="history-buttons">
+          <button className="undo-btn" onClick={undo} aria-label="Undo">
+            <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
+              <polyline
+                points="1 4 1 10 7 10"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <path
+                d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </button>
+          <button className="redo-btn" onClick={redo} aria-label="Redo">
+            <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
+              <polyline
+                points="23 4 23 10 17 10"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <path
+                d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </button>
+        </div>
         {name.startsWith('tool:') && (
           <button className="settings-btn" onClick={openCfg} title="Tool Settings">
             <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">

--- a/src/components/EditorPage.tsx
+++ b/src/components/EditorPage.tsx
@@ -4,10 +4,27 @@ import PropertiesPanel from './PropertiesPanel';
 import WorkflowManager from './WorkflowManager';
 import EditorHeader from './EditorHeader';
 import { useWorkflowStore } from '../store/workflowStore';
+import { useEffect } from 'react';
 
 export default function EditorPage({ onBack }: { onBack: () => void }) {
   const name = useWorkflowStore(s => s.workflowName);
+  const undo = useWorkflowStore(s => s.undo);
+  const redo = useWorkflowStore(s => s.redo);
   const editor: 'agent' | 'tool' = name.startsWith('tool:') ? 'tool' : 'agent';
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && !e.shiftKey && e.key === 'z') {
+        e.preventDefault();
+        undo();
+      } else if ((e.ctrlKey || e.metaKey) && (e.key === 'y' || (e.shiftKey && e.key === 'Z'))) {
+        e.preventDefault();
+        redo();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [undo, redo]);
   return (
     <main className="main editor-page">
       <EditorHeader onBack={onBack} />

--- a/src/components/PropertiesPanel.tsx
+++ b/src/components/PropertiesPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useWorkflowStore } from '../store/workflowStore';
 import type { Field, NodeInstance } from '../types';
 import type { JSX } from 'react';
@@ -34,6 +34,11 @@ function FieldInput({ field, node }: { field: Field; node: NodeInstance }) {
   const update = useWorkflowStore((s) => s.updateNodeField);
   const initial = node.fields[field.id] ?? field.default ?? '';
   const [value, setValue] = useState<any>(initial);
+
+  // keep input value in sync when undo/redo changes the node
+  useEffect(() => {
+    setValue(node.fields[field.id] ?? field.default ?? '');
+  }, [node.fields[field.id]]);
 
   const onChange = (val: unknown) => {
     setValue(val);

--- a/src/store/workflowStore.ts
+++ b/src/store/workflowStore.ts
@@ -20,6 +20,7 @@ interface WorkflowState {
   redoStack: { nodes: Record<string, NodeInstance>; edges: EdgeInstance[] }[];
   undo: () => void;
   redo: () => void;
+  recordSnapshot: () => void;
   workflowName: string;
   dirty: boolean;
   savedWorkflows: string[];
@@ -400,13 +401,14 @@ export const useWorkflowStore = create<WorkflowState>()(
       })),
 
       moveNode: (uuid, pos) =>
-        (pushUndo(),
         set((s) => {
           if (s.nodes[uuid]) {
             s.nodes[uuid].position = pos;
             s.dirty = true;
           }
-        })),
+        }),
+
+      recordSnapshot: pushUndo,
 
       undo: () => {
         const snap = snapshot();

--- a/src/theme.css
+++ b/src/theme.css
@@ -545,6 +545,14 @@
   top: 50%;
   transform: translateY(-50%);
 }
+.editor-header .history-buttons {
+  position: absolute;
+  left: 3rem;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  gap: 4px;
+}
 .editor-header .editor-title {
   margin: 0;
   display: flex;


### PR DESCRIPTION
## Summary
- implement history stacks in workflow store
- push snapshots on node/edge changes
- add undo/redo actions to workflow store
- handle Ctrl+Z / Ctrl+Y in `EditorPage`

## Testing
- `npm run verify`

------
https://chatgpt.com/codex/tasks/task_e_684bb4176b588327848a79c5f857d726