### PR TITLE
Add Express backend and API integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ dist-ssr
 .vite
 combined.md
 src/**/*.js
+server/**/*.js

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ This project implements a visual node editor for building AI workflows. The arch
 │   └─ nodeTypes.json # Node type definitions (see below)
 ├─ src/               # React + TypeScript source
 │   ├─ components/    # UI components (canvas, palette, workflow manager, etc.)
-│   ├─ store/         # Zustand state store with localStorage persistence
+│   ├─ store/         # Zustand state store with API persistence
 │   ├─ logic/         # Business logic helpers & validation
 │   │   └─ __tests__/ # Vitest unit tests
 │   ├─ index.css      # Base styles
@@ -18,6 +18,7 @@ This project implements a visual node editor for building AI workflows. The arch
 │   └─ types.ts       # Shared TypeScript interfaces
 ├─ index.html         # Vite entry page
 ├─ vite.config.ts     # Vite configuration
+├─ server/            # Express backend for storing data
 └─ DesignDoc.md       # Detailed design document
 ```
 
@@ -65,16 +66,17 @@ App
 ```
 
 ### Data Flow
-1. `App.tsx` loads `nodeTypes.json` and populates the store with `NodeType` objects and the type hierarchy.
+1. `App.tsx` requests `/api/v1/nodeTypes` and populates the store with `NodeType` objects and the type hierarchy.
 2. Dragging from the palette spawns nodes on the canvas with new UUIDs.
 3. Connections are created via React Flow and validated by `logic/pinValidation.ts`.
 4. Selecting a node opens its fields in `PropertiesPanel` for editing.
-5. Workflows auto-save to `localStorage`; `WorkflowManager` lets users save, load and delete named flows.
-6. Theme preference is persisted in `localStorage`.
+5. Workflows auto-save to the Express backend; `WorkflowManager` uses the versioned REST API for CRUD operations.
+6. Theme preference and other settings are stored via `/api/v1/settings`.
 
 ### Notes for Contributors
-- Follow the design intent in `DesignDoc.md` when adding features or refactoring.
-- Run `npm run verify` before committing changes to compile, type-check and run the tests.
-- The repo currently uses plain CSS; switch to CSS Modules or Tailwind only if consistent with the design doc.
+ - Follow the design intent in `DesignDoc.md` when adding features or refactoring.
+ - Use `npm run server` to start the backend during development.
+ - Run `npm run verify` before committing changes to compile, type-check and run both client and server tests.
+ - The repo currently uses plain CSS; switch to CSS Modules or Tailwind only if consistent with the design doc.
 - If the project structure or workflow changes, **update this `AGENTS.md`** to keep it current.
 - When submitting a PR with significant changes, add, modify or remove sections of this file so it accurately reflects the new state of the project.

--- a/DesignDoc.md
+++ b/DesignDoc.md
@@ -39,8 +39,27 @@ _Version 0.2 – June 7 2025 (adds single-element-per-row node layout)_
 
 ## Purpose & Scope
 
-This document specifies the **client-side** design for a _visual node editor_ that lets users compose AI-agent workflows by dragging node types onto a canvas and wiring them together.  
-Server concerns (authentication, storage, execution, collaboration) are **out of scope** for this phase.
+This document specifies the **client-side** design for a _visual node editor_ that lets users compose AI-agent workflows by dragging node types onto a canvas and wiring them together.
+
+### Server Responsibilities
+
+The project now ships with a lightweight Express backend. The server is responsible for executing workflows and persisting all editor data:
+
+- Node type definitions
+- Saved agents/workflows
+- Custom tools
+- Assistant profiles
+- Chat history
+- User settings
+
+It exposes a simple versioned REST API consumed by the client:
+
+- `GET /api/v1/nodeTypes` – node type catalog.
+- `GET`, `POST` and `DELETE` `/api/v1/workflows` – workflow CRUD.
+- `GET`, `POST` and `DELETE` `/api/v1/tools` – tool definitions.
+- `GET`, `POST` and `DELETE` `/api/v1/assistants` – assistant records.
+- `GET` and `POST` `/api/v1/chats` – chat history.
+- `GET` and `POST` `/api/v1/settings` – UI preferences.
 
 ## Glossary
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@xyflow/react": "^12.6.4",
         "clsx": "^2.1.1",
+        "express": "^4.19.2",
         "immer": "^10.1.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -17,13 +18,17 @@
         "zustand": "^5.0.5"
       },
       "devDependencies": {
+        "@types/express": "^4.17.21",
         "@types/node": "^20.11.17",
         "@types/react": "^19.1.6",
         "@types/react-dom": "^19.1.6",
+        "@types/supertest": "^2.0.12",
         "@typescript-eslint/eslint-plugin": "^8.33.1",
         "@typescript-eslint/parser": "^8.33.1",
         "@vitejs/plugin-react": "^4.5.1",
         "eslint": "^9.28.0",
+        "supertest": "^6.3.3",
+        "ts-node": "^10.9.2",
         "typescript": "^5.8.3",
         "vite": "^6.3.5",
         "vitest": "^1.5.0"
@@ -333,6 +338,30 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1091,6 +1120,19 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1127,6 +1169,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
+      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -1423,6 +1475,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1467,6 +1547,34 @@
       "dependencies": {
         "@babel/types": "^7.20.7"
       }
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/d3-color": {
       "version": "3.1.3",
@@ -1524,10 +1632,57 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/express": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.23.tgz",
+      "integrity": "sha512-Crp6WY9aTYP3qPi2wGDo9iUe/rceX01UMhnF1jmwDcKCFM6cx7YhGP/Mpr3y9AASpfHixIG0E6azCcL5OcDHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.19.6",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
+      "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
       "dev": true,
       "license": "MIT"
     },
@@ -1540,6 +1695,20 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.1.6",
@@ -1559,6 +1728,52 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
+      }
+    },
+    "node_modules/@types/send": {
+      "version": "0.17.5",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.5.tgz",
+      "integrity": "sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.8",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.8.tgz",
+      "integrity": "sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/superagent": {
+      "version": "8.1.9",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
+      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-2.0.16.tgz",
+      "integrity": "sha512-6c2ogktZ06tr2ENoZivgm7YnprnhYE4ZoXGMY+oA7IuAf17M8FWvujXZGmxLv8y0PTyts4x5A+erSwVUFA8XSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/superagent": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -1977,6 +2192,19 @@
         "d3-zoom": "^3.0.0"
       }
     },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.14.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
@@ -2046,12 +2274,32 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/assertion-error": {
       "version": "1.1.0",
@@ -2063,11 +2311,57 @@
         "node": "*"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.13.0",
+        "raw-body": "2.5.2",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
@@ -2126,6 +2420,15 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -2134,6 +2437,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -2251,6 +2583,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2265,10 +2620,60 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2437,6 +2842,56 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
@@ -2447,12 +2902,87 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.165",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.165.tgz",
       "integrity": "sha512-naiMx1Z6Nb2TxPU6fiFrUrDTjyPMLdTtaOd2oLmG8zVSg2hCWGkhPyxwk+qRmZ1ytwVqUv0u7ZcDA5+ALhaUtw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.25.5",
@@ -2504,6 +3034,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -2743,6 +3279,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/execa": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
@@ -2766,6 +3311,67 @@
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
+    },
+    "node_modules/express": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.3",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.7.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.3.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.13.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -2818,6 +3424,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -2853,6 +3466,39 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/finalhandler/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/finalhandler/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -2892,6 +3538,57 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/form-data": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
+      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.5.tgz",
+      "integrity": "sha512-Oz5Hwvwak/DCaXVVUtPn4oLMLLy1CdclLKO1LFgU7XzDpVMUU5UjlSLpGMocyQNNk8F6IJW9M/YdooSn2MRI+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0",
+        "qs": "^6.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2905,6 +3602,15 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/gensync": {
@@ -2925,6 +3631,43 @@
       "license": "MIT",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -2963,6 +3706,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -2980,6 +3735,62 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/human-signals": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
@@ -2988,6 +3799,18 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -3035,6 +3858,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-extglob": {
@@ -3251,6 +4089,40 @@
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -3268,6 +4140,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -3280,6 +4161,39 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/mimic-fn": {
@@ -3335,7 +4249,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -3363,6 +4276,15 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.19",
@@ -3398,6 +4320,40 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/onetime": {
@@ -3479,6 +4435,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3498,6 +4463,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
     },
     "node_modules/pathe": {
       "version": "1.1.2",
@@ -3622,6 +4593,19 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3630,6 +4614,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue-microtask": {
@@ -3652,6 +4651,30 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/react": {
       "version": "19.1.0",
@@ -3783,6 +4806,32 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
@@ -3801,6 +4850,75 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/send": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/send/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.19.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -3823,6 +4941,78 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -3861,6 +5051,15 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/std-env": {
       "version": "3.9.0",
@@ -3914,6 +5113,56 @@
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/superagent": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
+      "integrity": "sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==",
+      "deprecated": "Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^2.1.2",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.0",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">=6.4.0 <13 || >=14"
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.3.4.tgz",
+      "integrity": "sha512-erY3HFDG0dPnhw4U+udPfrzXa4xhSG+n4rxfRuZWCUvjFWwKl+OxWf/7zk50s84/fAAs7vf5QAb9uRa0cCykxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^8.1.2"
+      },
+      "engines": {
+        "node": ">=6.4.0"
+      }
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -4013,6 +5262,15 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -4024,6 +5282,50 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
       }
     },
     "node_modules/type-check": {
@@ -4047,6 +5349,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/typescript": {
@@ -4076,6 +5391,15 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
@@ -4127,6 +5451,15 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/uuid": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
@@ -4138,6 +5471,22 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/vite": {
@@ -5355,12 +6704,29 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "server": "ts-node --project tsconfig.server.json server/index.ts",
     "build": "tsc && vite build",
     "preview": "vite preview",
     "lint": "eslint \"src/**/*.{ts,tsx,js}\" --max-warnings 0",
@@ -20,7 +21,8 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "uuid": "^11.1.0",
-    "zustand": "^5.0.5"
+    "zustand": "^5.0.5",
+    "express": "^4.19.2"
   },
   "devDependencies": {
     "@types/node": "^20.11.17",
@@ -32,6 +34,10 @@
     "eslint": "^9.28.0",
     "typescript": "^5.8.3",
     "vite": "^6.3.5",
-    "vitest": "^1.5.0"
+    "vitest": "^1.5.0",
+    "ts-node": "^10.9.2",
+    "supertest": "^6.3.3",
+    "@types/express": "^4.17.21",
+    "@types/supertest": "^2.0.12"
   }
 }

--- a/server/__tests__/routes.test.ts
+++ b/server/__tests__/routes.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import request from 'supertest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { createServer } from '../index.js';
+
+let dataDir: string;
+let app: ReturnType<typeof createServer>["app"];
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), 'flai-'));
+  app = createServer({ dataDir }).app;
+});
+
+afterEach(() => {
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe('workflow routes', () => {
+  it('creates, reads and deletes workflows', async () => {
+    await request(app)
+      .post('/api/v1/workflows/test')
+      .send({ nodes: {}, edges: [] })
+      .expect(200);
+
+    const list = await request(app).get('/api/v1/workflows');
+    expect(list.body).toContain('test');
+
+    const wf = await request(app).get('/api/v1/workflows/test');
+    expect(wf.body).toEqual({ nodes: {}, edges: [] });
+
+    await request(app).delete('/api/v1/workflows/test').expect(200);
+    const list2 = await request(app).get('/api/v1/workflows');
+    expect(list2.body).not.toContain('test');
+  });
+});

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,0 +1,141 @@
+import express from 'express';
+import { join } from 'path';
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { fileURLToPath } from 'url';
+import type { ToolData, AssistantData, Chat, Settings } from './types.js';
+
+function loadJSON<T>(dir: string, name: string, fallback: T): T {
+  const file = join(dir, name);
+  if (!existsSync(file)) return fallback;
+  try {
+    return JSON.parse(readFileSync(file, 'utf-8')) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+function saveJSON(dir: string, name: string, data: unknown) {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, name), JSON.stringify(data, null, 2));
+}
+
+export function createServer(opts: { dataDir?: string } = {}) {
+  const __dirname = fileURLToPath(new URL('.', import.meta.url));
+  const dataDir = opts.dataDir || join(__dirname, 'data');
+
+  const workflows: Record<string, ToolData> = loadJSON(dataDir, 'workflows.json', {});
+  const tools: Record<string, ToolData> = loadJSON(dataDir, 'tools.json', {});
+  const assistants: Record<string, AssistantData> = loadJSON(dataDir, 'assistants.json', {});
+  const chats: Chat[] = loadJSON(dataDir, 'chats.json', []);
+  const settings: Settings = loadJSON(dataDir, 'settings.json', { theme: 'light' });
+
+  const app = express();
+  app.use(express.json());
+
+  const router = express.Router();
+
+  router.get('/nodeTypes', (_req, res) => {
+    res.sendFile(join(__dirname, '../public/nodeTypes.json'));
+  });
+
+  // workflows
+  router.get('/workflows', (_req, res) => {
+    res.json(Object.keys(workflows));
+  });
+
+  router.get('/workflows/:name', (req, res) => {
+    res.json(workflows[req.params.name] || null);
+  });
+
+  router.post('/workflows/:name', (req, res) => {
+    workflows[req.params.name] = req.body;
+    saveJSON(dataDir, 'workflows.json', workflows);
+    res.json({ ok: true });
+  });
+
+  router.delete('/workflows/:name', (req, res) => {
+    delete workflows[req.params.name];
+    saveJSON(dataDir, 'workflows.json', workflows);
+    res.json({ ok: true });
+  });
+
+  // tools
+  router.get('/tools', (_req, res) => {
+    res.json(Object.keys(tools));
+  });
+
+  router.get('/tools/:name', (req, res) => {
+    res.json(tools[req.params.name] || null);
+  });
+
+  router.post('/tools/:name', (req, res) => {
+    tools[req.params.name] = req.body;
+    saveJSON(dataDir, 'tools.json', tools);
+    res.json({ ok: true });
+  });
+
+  router.delete('/tools/:name', (req, res) => {
+    delete tools[req.params.name];
+    saveJSON(dataDir, 'tools.json', tools);
+    res.json({ ok: true });
+  });
+
+  // assistants
+  router.get('/assistants', (_req, res) => {
+    res.json(Object.keys(assistants));
+  });
+
+  router.get('/assistants/:name', (req, res) => {
+    res.json(assistants[req.params.name] || null);
+  });
+
+  router.post('/assistants/:name', (req, res) => {
+    assistants[req.params.name] = req.body;
+    saveJSON(dataDir, 'assistants.json', assistants);
+    res.json({ ok: true });
+  });
+
+  router.delete('/assistants/:name', (req, res) => {
+    delete assistants[req.params.name];
+    saveJSON(dataDir, 'assistants.json', assistants);
+    res.json({ ok: true });
+  });
+
+  // chats
+  router.get('/chats', (_req, res) => {
+    res.json(chats);
+  });
+
+  router.post('/chats', (req, res) => {
+    chats.length = 0;
+    chats.push(...req.body);
+    saveJSON(dataDir, 'chats.json', chats);
+    res.json({ ok: true });
+  });
+
+  // settings
+  router.get('/settings', (_req, res) => {
+    res.json(settings);
+  });
+
+  router.post('/settings', (req, res) => {
+    Object.assign(settings, req.body);
+    saveJSON(dataDir, 'settings.json', settings);
+    res.json({ ok: true });
+  });
+
+  app.use('/api/v1', router);
+
+  // TODO: remove these deprecated routes in v2
+  app.use('/api', router);
+
+  return { app };
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const { app } = createServer();
+  const port = process.env.PORT || 3000;
+  app.listen(port, () => {
+    console.log(`Server listening on ${port}`);
+  });
+}

--- a/server/types.ts
+++ b/server/types.ts
@@ -1,0 +1,80 @@
+export type PinCardinality = 'one' | 'many' | { exact: number };
+
+export interface Pin {
+  id: string;
+  name: string;
+  direction: 'input' | 'output';
+  type: string;
+  cardinality: PinCardinality;
+  required?: boolean;
+}
+
+export interface Field {
+  id: string;
+  name: string;
+  label: string;
+  type: 'string' | 'integer' | 'float' | 'bool' | 'enum';
+  required?: boolean;
+  options?: string[];
+  default?: unknown;
+}
+
+export interface NodeType {
+  id: string;
+  name: string;
+  icon?: string;
+  tags: string[];
+  category?: string;
+  layout: 'singleRow';
+  inputs: Pin[];
+  outputs: Pin[];
+  fields: Field[];
+  editors?: ('tool' | 'agent')[];
+}
+
+export interface NodeInstance {
+  uuid: string;
+  nodeTypeId: string;
+  position: { x: number; y: number };
+  fields: Record<string, unknown>;
+}
+
+export interface EdgeInstance {
+  id: string;
+  from: { uuid: string; pin: string };
+  to: { uuid: string; pin: string };
+}
+
+export interface ToolMeta {
+  name: string;
+  description: string;
+  schema: string;
+}
+
+export interface ToolData {
+  meta: ToolMeta;
+  nodes: Record<string, NodeInstance>;
+  edges: EdgeInstance[];
+}
+
+export interface AssistantData {
+  name: string;
+  system: string;
+  model: string;
+  tools: string[];
+}
+
+export interface ChatMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+export interface Chat {
+  id: number;
+  title: string;
+  messages: ChatMessage[];
+}
+
+export interface Settings {
+  theme: 'light' | 'dark';
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,7 +35,7 @@ export default function App() {
   const [editingAssistant, setEditingAssistant] = useState<string | null>(null);
 
   useEffect(() => {
-    fetch(`${import.meta.env.BASE_URL}nodeTypes.json`)
+    fetch('/api/v1/nodeTypes')
       .then((r) => r.json())
       .then((json) => {
         loadDefs(json);

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,103 @@
+const prefix = '/api/v1';
+
+export async function getNodeTypes() {
+  const res = await fetch(`${prefix}/nodeTypes`);
+  return res.json();
+}
+
+// workflows
+export async function listWorkflows(): Promise<string[]> {
+  const res = await fetch(`${prefix}/workflows`);
+  return res.json();
+}
+
+export async function getWorkflow(name: string) {
+  const res = await fetch(`${prefix}/workflows/${encodeURIComponent(name)}`);
+  return res.json();
+}
+
+export async function saveWorkflow(name: string, data: unknown) {
+  await fetch(`${prefix}/workflows/${encodeURIComponent(name)}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+}
+
+export async function deleteWorkflow(name: string) {
+  await fetch(`${prefix}/workflows/${encodeURIComponent(name)}`, { method: 'DELETE' });
+}
+
+// tools
+export async function listTools(): Promise<string[]> {
+  const res = await fetch(`${prefix}/tools`);
+  return res.json();
+}
+
+export async function getTool(name: string) {
+  const res = await fetch(`${prefix}/tools/${encodeURIComponent(name)}`);
+  return res.json();
+}
+
+export async function saveTool(name: string, data: unknown) {
+  await fetch(`${prefix}/tools/${encodeURIComponent(name)}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+}
+
+export async function deleteTool(name: string) {
+  await fetch(`${prefix}/tools/${encodeURIComponent(name)}`, { method: 'DELETE' });
+}
+
+// assistants
+export async function listAssistants(): Promise<string[]> {
+  const res = await fetch(`${prefix}/assistants`);
+  return res.json();
+}
+
+export async function getAssistant(name: string) {
+  const res = await fetch(`${prefix}/assistants/${encodeURIComponent(name)}`);
+  return res.json();
+}
+
+export async function saveAssistant(name: string, data: unknown) {
+  await fetch(`${prefix}/assistants/${encodeURIComponent(name)}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+}
+
+export async function deleteAssistant(name: string) {
+  await fetch(`${prefix}/assistants/${encodeURIComponent(name)}`, { method: 'DELETE' });
+}
+
+// chats
+export async function getChats() {
+  const res = await fetch(`${prefix}/chats`);
+  return res.json();
+}
+
+export async function saveChats(data: unknown) {
+  await fetch(`${prefix}/chats`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+}
+
+// settings
+export async function getSettings() {
+  const res = await fetch(`${prefix}/settings`);
+  return res.json();
+}
+
+export async function saveSettings(data: unknown) {
+  await fetch(`${prefix}/settings`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+}

--- a/src/components/AssistantEditPage.tsx
+++ b/src/components/AssistantEditPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import * as api from '../api';
 
 interface AssistantData {
   name: string;
@@ -15,46 +16,41 @@ export default function AssistantEditPage({ name: orig, onBack }: { name: string
   const [available, setAvailable] = useState<string[]>([]);
 
   useEffect(() => {
-    const raw = localStorage.getItem(`assistant.${orig}`);
-    if (raw) {
-      try {
-        const parsed = JSON.parse(raw) as Partial<AssistantData>;
-        setName(parsed.name || orig);
-        setSystem(parsed.system || (parsed as any).instructions || '');
-        setModel(parsed.model || '');
-        setTools(parsed.tools || []);
-      } catch {
+    (async () => {
+      const data = await api.getAssistant(orig);
+      if (data) {
+        setName(data.name || orig);
+        setSystem(data.system || '');
+        setModel(data.model || '');
+        setTools(data.tools || []);
+      } else {
         setName(orig);
         setSystem('');
         setModel('');
         setTools([]);
       }
-    }
-    const list = localStorage.getItem('tools');
-    setAvailable(list ? JSON.parse(list) : []);
+      const list = await api.listTools();
+      setAvailable(list);
+    })();
   }, [orig]);
 
   const removeTool = (t: string) => {
     setTools(ts => ts.filter(x => x !== t));
   };
 
-  const save = () => {
-    const listRaw = localStorage.getItem('assistants');
-    const names: string[] = listRaw ? JSON.parse(listRaw) : [];
+  const save = async () => {
+    const names = await api.listAssistants();
     let target = orig;
     if (name && name !== orig) {
       if (names.includes(name)) {
         alert('Name already exists');
         return;
       }
-      const idx = names.indexOf(orig);
-      if (idx !== -1) names[idx] = name;
-      localStorage.removeItem(`assistant.${orig}`);
+      await api.deleteAssistant(orig);
       target = name;
     }
-    localStorage.setItem('assistants', JSON.stringify(names));
     const payload: AssistantData = { name: target, system, model, tools };
-    localStorage.setItem(`assistant.${target}`, JSON.stringify(payload));
+    await api.saveAssistant(target, payload);
     onBack();
   };
 

--- a/src/components/AssistantsPage.tsx
+++ b/src/components/AssistantsPage.tsx
@@ -1,12 +1,13 @@
 import { useState, useEffect } from 'react';
+import * as api from '../api';
 
 export default function AssistantsPage({ onOpen }: { onOpen: (name: string) => void }) {
   const [assistants, setAssistants] = useState<string[]>([]);
   const [query, setQuery] = useState('');
 
-  const refresh = () => {
-    const list = localStorage.getItem('assistants');
-    setAssistants(list ? JSON.parse(list) : []);
+  const refresh = async () => {
+    const list = await api.listAssistants();
+    setAssistants(list);
   };
 
   useEffect(() => {
@@ -14,29 +15,21 @@ export default function AssistantsPage({ onOpen }: { onOpen: (name: string) => v
   }, []);
 
 
-  const deleteAssistant = (name: string) => {
-    const listRaw = localStorage.getItem('assistants');
-    const names: string[] = listRaw ? JSON.parse(listRaw) : [];
-    const idx = names.indexOf(name);
-    if (idx !== -1) names.splice(idx, 1);
-    localStorage.setItem('assistants', JSON.stringify(names));
-    localStorage.removeItem(`assistant.${name}`);
+  const deleteAssistant = async (name: string) => {
+    await api.deleteAssistant(name);
+    const names = await api.listAssistants();
     setAssistants(names);
   };
 
-  const createAssistant = () => {
+  const createAssistant = async () => {
     const list = assistants.slice();
     let base = 'Untitled Assistant';
     let idx = 1;
     let name = `${base} ${idx}`;
     while (list.includes(name)) name = `${base} ${++idx}`;
-    localStorage.setItem(
-      `assistant.${name}`,
-      JSON.stringify({ name, instructions: '' })
-    );
-    list.push(name);
-    localStorage.setItem('assistants', JSON.stringify(list));
-    setAssistants(list);
+    await api.saveAssistant(name, { name, system: '', model: '', tools: [] });
+    const names = await api.listAssistants();
+    setAssistants(names);
     onOpen(name);
   };
 

--- a/src/components/ChatPage.tsx
+++ b/src/components/ChatPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import clsx from 'clsx';
+import * as api from '../api';
 
 interface Message {
   role: 'user' | 'assistant';
@@ -18,6 +19,18 @@ export default function ChatPage({ onBack }: { onBack: () => void }) {
   const [input, setInput] = useState('');
   const [collapsed, setCollapsed] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  useEffect(() => {
+    api.getChats().then((c) => {
+      if (c && c.length) {
+        setChats(c);
+        setActive(c[0].id);
+      } else {
+        createChat();
+      }
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const deleteChat = (id: number) => {
     setChats((cs) => {
@@ -68,6 +81,10 @@ export default function ChatPage({ onBack }: { onBack: () => void }) {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    api.saveChats(chats);
+  }, [chats]);
 
   useEffect(() => {
     resizeTextarea();

--- a/src/components/ToolsPage.tsx
+++ b/src/components/ToolsPage.tsx
@@ -3,6 +3,7 @@ import SchemaEditor from './SchemaEditor';
 import { v4 as uuid } from 'uuid';
 import { useWorkflowStore } from '../store/workflowStore';
 import type { NodeInstance, EdgeInstance, ToolData, ToolMeta } from '../types';
+import * as api from '../api';
 
 
 export default function ToolsPage({ onOpen }: { onOpen: (name: string) => void }) {
@@ -17,9 +18,9 @@ export default function ToolsPage({ onOpen }: { onOpen: (name: string) => void }
   const [metaSchema, setMetaSchema] = useState('');
   const [data, setData] = useState<ToolData | null>(null);
 
-  const refresh = () => {
-    const list = localStorage.getItem('tools');
-    setTools(list ? JSON.parse(list) : []);
+  const refresh = async () => {
+    const list = await api.listTools();
+    setTools(list);
     refreshNodes();
   };
 
@@ -27,16 +28,9 @@ export default function ToolsPage({ onOpen }: { onOpen: (name: string) => void }
     refresh();
   }, []);
 
-  const openEdit = (name: string) => {
-    const raw = localStorage.getItem(`tool.${name}`);
-    let parsed: ToolData;
-    if (raw) {
-      try {
-        parsed = JSON.parse(raw) as ToolData;
-      } catch {
-        parsed = { meta: { name, description: '', schema: '' }, nodes: {}, edges: [] };
-      }
-    } else {
+  const openEdit = async (name: string) => {
+    let parsed: ToolData | null = await api.getTool(name);
+    if (!parsed) {
       parsed = { meta: { name, description: '', schema: '' }, nodes: {}, edges: [] };
     }
 
@@ -69,7 +63,7 @@ export default function ToolsPage({ onOpen }: { onOpen: (name: string) => void }
     setData(parsed);
   };
 
-  const createTool = () => {
+  const createTool = async () => {
     const list = tools.slice();
     let base = 'Untitled Tool';
     let idx = 1;
@@ -97,19 +91,16 @@ export default function ToolsPage({ onOpen }: { onOpen: (name: string) => void }
       nodes: { [startId]: start, [endId]: end },
       edges: [],
     };
-    localStorage.setItem(`tool.${name}`, JSON.stringify(newData));
-    list.push(name);
-    localStorage.setItem('tools', JSON.stringify(list));
-    setTools(list);
+    await api.saveTool(name, newData);
+    const names = await api.listTools();
+    setTools(names);
     refreshNodes();
     openEdit(name);
   };
 
-  const saveTool = () => {
+  const saveTool = async () => {
     if (!editing || !data) return;
-    const list = localStorage.getItem('tools');
-    const names: string[] = list ? JSON.parse(list) : [];
-
+    const names = await api.listTools();
     data.meta = { name: metaName, description: metaDesc, schema: metaSchema };
 
     let target = editing;
@@ -119,25 +110,18 @@ export default function ToolsPage({ onOpen }: { onOpen: (name: string) => void }
         return;
       }
       target = metaName;
-      const idx = names.indexOf(editing);
-      if (idx !== -1) names[idx] = metaName;
-      localStorage.removeItem(`tool.${editing}`);
+      await api.deleteTool(editing);
     }
-    localStorage.setItem('tools', JSON.stringify(names));
-    localStorage.setItem(`tool.${target}`, JSON.stringify(data));
+    await api.saveTool(target, data);
     setEditing(null);
     setData(null);
     refresh();
     refreshNodes();
   };
 
-  const deleteTool = (name: string) => {
-    const list = localStorage.getItem('tools');
-    const names: string[] = list ? JSON.parse(list) : [];
-    const idx = names.indexOf(name);
-    if (idx !== -1) names.splice(idx, 1);
-    localStorage.setItem('tools', JSON.stringify(names));
-    localStorage.removeItem(`tool.${name}`);
+  const deleteTool = async (name: string) => {
+    await api.deleteTool(name);
+    const names = await api.listTools();
     setTools(names);
     refreshNodes();
   };

--- a/src/store/workflowStore.ts
+++ b/src/store/workflowStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
 import { v4 as uuid } from 'uuid';
 import type { NodeInstance, NodeType, EdgeInstance, ToolMeta, ToolData } from '../types';
+import * as api from '../api';
 
 interface WorkflowState {
   nodeTypes: NodeType[];
@@ -27,18 +28,18 @@ interface WorkflowState {
   toolMeta: ToolMeta | null;
   toast: { message: string; type: 'error' | 'success' } | null;
   setToast: (msg: string, type?: 'error' | 'success') => void;
-  refreshSavedWorkflows: () => void;
-  saveWorkflow: (name: string) => void;
-  loadWorkflow: (name: string) => void;
-  saveTool: (name: string) => void;
-  loadTool: (name: string) => void;
+  refreshSavedWorkflows: () => Promise<void>;
+  saveWorkflow: (name: string) => Promise<void>;
+  loadWorkflow: (name: string) => Promise<void>;
+  saveTool: (name: string) => Promise<void>;
+  loadTool: (name: string) => Promise<void>;
   setToolMeta: (meta: ToolMeta) => void;
-  deleteWorkflow: (name: string) => void;
-  duplicateWorkflow: (name: string) => void;
-  renameWorkflow: (oldName: string, newName: string) => void;
-  renameTool: (oldName: string, newName: string) => void;
-  refreshToolNodes: () => void;
-  createWorkflow: () => string;
+  deleteWorkflow: (name: string) => Promise<void>;
+  duplicateWorkflow: (name: string) => Promise<void>;
+  renameWorkflow: (oldName: string, newName: string) => Promise<void>;
+  renameTool: (oldName: string, newName: string) => Promise<void>;
+  refreshToolNodes: () => Promise<void>;
+  createWorkflow: () => Promise<string>;
 
   loadDefinitions: (json: {
     types: Record<string, string | null>;
@@ -52,7 +53,7 @@ interface WorkflowState {
   openContextMenu: (
     menu: { type: 'node' | 'edge'; id: string; position: { x: number; y: number } } | null
   ) => void;
-  setTheme: (t: 'light' | 'dark') => void;
+  setTheme: (t: 'light' | 'dark') => Promise<void>;
   setSelected: (ids: string[]) => void;
   openEditor: (id: string) => void;
   closeEditor: () => void;
@@ -70,6 +71,12 @@ export const useWorkflowStore = create<WorkflowState>()(
         s.redoStack = [];
       });
 
+    api.getSettings().then((cfg) =>
+      set((s) => {
+        if (cfg && cfg.theme) s.theme = cfg.theme as 'light' | 'dark';
+      })
+    );
+
     return {
     toast: null,
     nodeTypes: [],
@@ -79,11 +86,7 @@ export const useWorkflowStore = create<WorkflowState>()(
     selected: [],
     editing: null,
     contextMenu: null,
-    theme:
-      (localStorage.getItem('theme') as 'light' | 'dark') ||
-      (window.matchMedia('(prefers-color-scheme: dark)').matches
-        ? 'dark'
-        : 'light'),
+    theme: 'light',
     undoStack: [],
     redoStack: [],
     workflowName: 'autosave',
@@ -98,83 +101,59 @@ export const useWorkflowStore = create<WorkflowState>()(
         setTimeout(() => set((st) => void (st.toast = null)), 3000);
       }),
 
-    refreshSavedWorkflows: () =>
+    refreshSavedWorkflows: async () => {
+      const names = await api.listWorkflows();
       set((s) => {
-        const list = localStorage.getItem('workflows');
-        s.savedWorkflows = list ? JSON.parse(list) : [];
-      }),
+        s.savedWorkflows = names;
+      });
+    },
 
-    saveWorkflow: (name) =>
+    saveWorkflow: async (name) => {
+      await api.saveWorkflow(name, { nodes: get().nodes, edges: get().edges });
+      await get().refreshSavedWorkflows();
       set((s) => {
-        localStorage.setItem(
-          `workflow.${name}`,
-          JSON.stringify({ nodes: s.nodes, edges: s.edges })
-        );
-        const list = localStorage.getItem('workflows');
-        const names = list ? JSON.parse(list) : [];
-        if (!names.includes(name)) {
-          names.push(name);
-          localStorage.setItem('workflows', JSON.stringify(names));
-        }
         s.workflowName = name;
         s.dirty = false;
-        s.savedWorkflows = names;
-      }),
+      });
+    },
 
-      loadWorkflow: (name) =>
-        set((s) => {
-          const data = localStorage.getItem(`workflow.${name}`);
-          if (!data) return;
-          try {
-            const parsed = JSON.parse(data) as {
-              nodes: Record<string, NodeInstance>;
-              edges: EdgeInstance[];
-            };
-            s.nodes = parsed.nodes;
-            s.edges = parsed.edges;
-            s.workflowName = name;
-            s.dirty = false;
-            s.undoStack = [];
-            s.redoStack = [];
-          } catch {
-            /* ignore parse errors */
-          }
-        }),
-
-    saveTool: (name) => {
+    loadWorkflow: async (name) => {
+      const data = await api.getWorkflow(name);
+      if (!data) return;
       set((s) => {
-        const meta = s.toolMeta || { name, description: '', schema: '' };
-        const payload: ToolData = { meta, nodes: s.nodes, edges: s.edges };
-        localStorage.setItem(`tool.${name}`, JSON.stringify(payload));
-        const list = localStorage.getItem('tools');
-        const names = list ? JSON.parse(list) : [];
-        if (!names.includes(name)) {
-          names.push(name);
-          localStorage.setItem('tools', JSON.stringify(names));
-        }
+        s.nodes = data.nodes;
+        s.edges = data.edges;
+        s.workflowName = name;
+        s.dirty = false;
+        s.undoStack = [];
+        s.redoStack = [];
+      });
+    },
+
+    saveTool: async (name) => {
+      const meta = get().toolMeta || { name, description: '', schema: '' };
+      const payload: ToolData = { meta, nodes: get().nodes, edges: get().edges };
+      await api.saveTool(name, payload);
+      set((s) => {
         s.workflowName = `tool:${name}`;
         s.dirty = false;
       });
-      get().refreshToolNodes();
+      await get().refreshToolNodes();
     },
 
-      loadTool: (name) =>
-        set((s) => {
-          const data = localStorage.getItem(`tool.${name}`);
-          if (!data) return;
-          try {
-            const parsed = JSON.parse(data) as ToolData;
-            s.nodes = parsed.nodes;
-            s.edges = parsed.edges;
-            s.toolMeta = parsed.meta || { name, description: '', schema: '' };
-            s.workflowName = `tool:${name}`;
-            s.dirty = false;
-            s.undoStack = [];
-            s.redoStack = [];
-          } catch {
-            /* ignore parse errors */
-          }
-        }),
+    loadTool: async (name) => {
+      const data = await api.getTool(name);
+      if (!data) return;
+      set((s) => {
+        s.nodes = data.nodes;
+        s.edges = data.edges;
+        s.toolMeta = data.meta || { name, description: '', schema: '' };
+        s.workflowName = `tool:${name}`;
+        s.dirty = false;
+        s.undoStack = [];
+        s.redoStack = [];
+      });
+    },
 
     setToolMeta: (meta) =>
       set((s) => {
@@ -182,76 +161,54 @@ export const useWorkflowStore = create<WorkflowState>()(
         s.dirty = true;
       }),
 
-    deleteWorkflow: (name) =>
+    deleteWorkflow: async (name) => {
+      await api.deleteWorkflow(name);
+      await get().refreshSavedWorkflows();
       set((s) => {
-        localStorage.removeItem(`workflow.${name}`);
-        const list = localStorage.getItem('workflows');
-        const names = list ? JSON.parse(list) : [];
-        const index = names.indexOf(name);
-        if (index !== -1) {
-          names.splice(index, 1);
-          localStorage.setItem('workflows', JSON.stringify(names));
-        }
         if (s.workflowName === name) {
           s.workflowName = 'autosave';
           s.dirty = true;
         }
-        s.savedWorkflows = names;
-      }),
-
-    duplicateWorkflow: (name) =>
-      set((s) => {
-        const data = localStorage.getItem(`workflow.${name}`);
-        if (!data) return;
-        const list = localStorage.getItem('workflows');
-        const names = list ? JSON.parse(list) : [];
-        let newName = `${name} copy`;
-        let i = 2;
-        while (names.includes(newName)) {
-          newName = `${name} copy ${i++}`;
-        }
-        localStorage.setItem(`workflow.${newName}`, data);
-        names.push(newName);
-        localStorage.setItem('workflows', JSON.stringify(names));
-        s.savedWorkflows = names;
-      }),
-
-    renameWorkflow: (oldName, newName) =>
-      set((s) => {
-        const data = localStorage.getItem(`workflow.${oldName}`);
-        if (!data) return;
-        localStorage.setItem(`workflow.${newName}`, data);
-        localStorage.removeItem(`workflow.${oldName}`);
-        const list = localStorage.getItem('workflows');
-        let names = list ? JSON.parse(list) : [];
-        const idx = names.indexOf(oldName);
-        if (idx !== -1) names.splice(idx, 1);
-        if (!names.includes(newName)) names.push(newName);
-        localStorage.setItem('workflows', JSON.stringify(names));
-        if (s.workflowName === oldName) s.workflowName = newName;
-        s.savedWorkflows = names;
-      }),
-
-    renameTool: (oldName, newName) => {
-      set((s) => {
-        const data = localStorage.getItem(`tool.${oldName}`);
-        if (!data) return;
-        localStorage.setItem(`tool.${newName}`, data);
-        localStorage.removeItem(`tool.${oldName}`);
-        const list = localStorage.getItem('tools');
-        let names = list ? JSON.parse(list) : [];
-        const idx = names.indexOf(oldName);
-        if (idx !== -1) names.splice(idx, 1);
-        if (!names.includes(newName)) names.push(newName);
-        localStorage.setItem('tools', JSON.stringify(names));
-        if (s.workflowName === `tool:${oldName}`) s.workflowName = `tool:${newName}`;
       });
-      get().refreshToolNodes();
     },
 
-    refreshToolNodes: () => {
-      const list = localStorage.getItem('tools');
-      const names: string[] = list ? JSON.parse(list) : [];
+    duplicateWorkflow: async (name) => {
+      const data = await api.getWorkflow(name);
+      if (!data) return;
+      const names = await api.listWorkflows();
+      let newName = `${name} copy`;
+      let i = 2;
+      while (names.includes(newName)) {
+        newName = `${name} copy ${i++}`;
+      }
+      await api.saveWorkflow(newName, data);
+      await get().refreshSavedWorkflows();
+    },
+
+    renameWorkflow: async (oldName, newName) => {
+      const data = await api.getWorkflow(oldName);
+      if (!data) return;
+      await api.deleteWorkflow(oldName);
+      await api.saveWorkflow(newName, data);
+      await get().refreshSavedWorkflows();
+      set((s) => {
+        if (s.workflowName === oldName) s.workflowName = newName;
+      });
+    },
+
+    renameTool: async (oldName, newName) => {
+      const data = await api.getTool(oldName);
+      if (!data) return;
+      await api.deleteTool(oldName);
+      await api.saveTool(newName, data);
+      if (get().workflowName === `tool:${oldName}`) {
+        set((s) => { s.workflowName = `tool:${newName}`; });
+      }
+      await get().refreshToolNodes();
+    },
+
+    refreshToolNodes: async () => {
+      const names: string[] = await api.listTools();
       set((s) => {
         s.nodeTypes = s.nodeTypes.filter(
           (nt) => !nt.id.startsWith('tool.custom.')
@@ -284,9 +241,8 @@ export const useWorkflowStore = create<WorkflowState>()(
       });
     },
 
-    createWorkflow: () => {
-      const list = localStorage.getItem('workflows');
-      const names = list ? JSON.parse(list) : ([] as string[]);
+    createWorkflow: async () => {
+      const names = await api.listWorkflows();
       let idx = 1;
       const base = 'Untitled';
       let name = `${base} ${idx}`;
@@ -302,6 +258,8 @@ export const useWorkflowStore = create<WorkflowState>()(
         s.undoStack = [];
         s.redoStack = [];
       });
+      await api.saveWorkflow(name, { nodes: {}, edges: [] });
+      await get().refreshSavedWorkflows();
       return name;
     },
 
@@ -370,11 +328,12 @@ export const useWorkflowStore = create<WorkflowState>()(
         s.contextMenu = menu;
       }),
 
-    setTheme: (t) =>
+    setTheme: async (t) => {
+      await api.saveSettings({ theme: t });
       set((s) => {
         s.theme = t;
-        localStorage.setItem('theme', t);
-      }),
+      });
+    },
 
     setSelected: (ids) =>
       set((s) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,5 @@
     "baseUrl": "./src",
     "types": ["vite/client", "node"]
   },
-  "include": ["src"]
+  "include": ["src", "server"]
 }

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext"
+  },
+  "include": ["server"]
+}


### PR DESCRIPTION
## Summary
- document server responsibilities and REST API
- add Express backend under `server/`
- fetch node types and data through `/api/*` routes
- persist workflows, tools, assistants and chats via the backend
- update project guide and scripts for running the server
- prefix API routes with `/api/v1`

## Testing
- `npm run verify`


------
https://chatgpt.com/codex/tasks/task_e_684bc66e090883278b4acecba233bf39